### PR TITLE
Fix tool names to comply with MCP spec (dots → underscores)

### DIFF
--- a/ImmichMCP/Tools/ActivityTools.cs
+++ b/ImmichMCP/Tools/ActivityTools.cs
@@ -13,7 +13,7 @@ namespace ImmichMCP.Tools;
 [McpServerToolType]
 public static class ActivityTools
 {
-    [McpServerTool(Name = "immich.activities.list")]
+    [McpServerTool(Name = "immich_activities_list")]
     [Description("List activities (comments and likes) for an album or asset.")]
     public static async Task<string> List(
         ImmichClient client,
@@ -47,7 +47,7 @@ public static class ActivityTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.activities.create")]
+    [McpServerTool(Name = "immich_activities_create")]
     [Description("Create a comment or like on an album or asset.")]
     public static async Task<string> Create(
         ImmichClient client,
@@ -123,7 +123,7 @@ public static class ActivityTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.activities.delete")]
+    [McpServerTool(Name = "immich_activities_delete")]
     [Description("Delete an activity (comment or like).")]
     public static async Task<string> Delete(
         ImmichClient client,
@@ -160,7 +160,7 @@ public static class ActivityTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.activities.statistics")]
+    [McpServerTool(Name = "immich_activities_statistics")]
     [Description("Get activity statistics (comment count) for an album or asset.")]
     public static async Task<string> Statistics(
         ImmichClient client,

--- a/ImmichMCP/Tools/AlbumTools.cs
+++ b/ImmichMCP/Tools/AlbumTools.cs
@@ -14,7 +14,7 @@ namespace ImmichMCP.Tools;
 [McpServerToolType]
 public static class AlbumTools
 {
-    [McpServerTool(Name = "immich.albums.list")]
+    [McpServerTool(Name = "immich_albums_list")]
     [Description("List all albums with optional filters.")]
     public static async Task<string> List(
         ImmichClient client,
@@ -36,7 +36,7 @@ public static class AlbumTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.albums.get")]
+    [McpServerTool(Name = "immich_albums_get")]
     [Description("Get album details by ID.")]
     public static async Task<string> Get(
         ImmichClient client,
@@ -62,7 +62,7 @@ public static class AlbumTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.albums.create")]
+    [McpServerTool(Name = "immich_albums_create")]
     [Description("Create a new album.")]
     public static async Task<string> Create(
         ImmichClient client,
@@ -108,7 +108,7 @@ public static class AlbumTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.albums.update")]
+    [McpServerTool(Name = "immich_albums_update")]
     [Description("Update album metadata (name, description).")]
     public static async Task<string> Update(
         ImmichClient client,
@@ -145,7 +145,7 @@ public static class AlbumTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.albums.assets.add")]
+    [McpServerTool(Name = "immich_albums_assets_add")]
     [Description("Add assets to an album.")]
     public static async Task<string> AddAssets(
         ImmichClient client,
@@ -192,7 +192,7 @@ public static class AlbumTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.albums.assets.remove")]
+    [McpServerTool(Name = "immich_albums_assets_remove")]
     [Description("Remove assets from an album.")]
     public static async Task<string> RemoveAssets(
         ImmichClient client,
@@ -239,7 +239,7 @@ public static class AlbumTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.albums.delete")]
+    [McpServerTool(Name = "immich_albums_delete")]
     [Description("Delete an album. Requires explicit confirmation.")]
     public static async Task<string> Delete(
         ImmichClient client,
@@ -294,7 +294,7 @@ public static class AlbumTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.albums.statistics")]
+    [McpServerTool(Name = "immich_albums_statistics")]
     [Description("Get album statistics (owned, shared, not shared counts).")]
     public static async Task<string> Statistics(ImmichClient client)
     {

--- a/ImmichMCP/Tools/AssetTools.cs
+++ b/ImmichMCP/Tools/AssetTools.cs
@@ -14,7 +14,7 @@ namespace ImmichMCP.Tools;
 [McpServerToolType]
 public static class AssetTools
 {
-    [McpServerTool(Name = "immich.assets.list")]
+    [McpServerTool(Name = "immich_assets_list")]
     [Description("List recent assets with optional filters and pagination.")]
     public static async Task<string> List(
         ImmichClient client,
@@ -47,7 +47,7 @@ public static class AssetTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.assets.get")]
+    [McpServerTool(Name = "immich_assets_get")]
     [Description("Get full asset metadata by ID.")]
     public static async Task<string> Get(
         ImmichClient client,
@@ -72,7 +72,7 @@ public static class AssetTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.assets.exif")]
+    [McpServerTool(Name = "immich_assets_exif")]
     [Description("Get EXIF metadata for an asset.")]
     public static async Task<string> GetExif(
         ImmichClient client,
@@ -107,7 +107,7 @@ public static class AssetTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.assets.download.original")]
+    [McpServerTool(Name = "immich_assets_download_original")]
     [Description("Get download URL for the original asset file.")]
     public static async Task<string> DownloadOriginal(
         ImmichClient client,
@@ -141,7 +141,7 @@ public static class AssetTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.assets.download.thumbnail")]
+    [McpServerTool(Name = "immich_assets_download_thumbnail")]
     [Description("Get thumbnail and preview URLs for an asset.")]
     public static async Task<string> DownloadThumbnail(
         ImmichClient client,
@@ -175,7 +175,7 @@ public static class AssetTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.assets.upload")]
+    [McpServerTool(Name = "immich_assets_upload")]
     [Description("Upload a new asset from base64-encoded content. For large files, use immich.assets.upload_from_path instead.")]
     public static async Task<string> Upload(
         ImmichClient client,
@@ -234,7 +234,7 @@ public static class AssetTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.assets.upload_from_path")]
+    [McpServerTool(Name = "immich_assets_upload_from_path")]
     [Description("Upload an asset from a file path accessible to the MCP server. NOTE: Only works when the MCP server can access the path (e.g., stdio mode or shared filesystem). For remote HTTP mode, use immich.assets.upload with base64 content instead.")]
     public static async Task<string> UploadFromPath(
         ImmichClient client,
@@ -302,7 +302,7 @@ public static class AssetTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.assets.update")]
+    [McpServerTool(Name = "immich_assets_update")]
     [Description("Update asset metadata (favorite status, description, date, location, etc.).")]
     public static async Task<string> Update(
         ImmichClient client,
@@ -345,7 +345,7 @@ public static class AssetTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.assets.bulk_update")]
+    [McpServerTool(Name = "immich_assets_bulk_update")]
     [Description("Perform bulk operations on multiple assets. Supports dry run mode.")]
     public static async Task<string> BulkUpdate(
         ImmichClient client,
@@ -420,7 +420,7 @@ public static class AssetTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.assets.delete")]
+    [McpServerTool(Name = "immich_assets_delete")]
     [Description("Delete asset(s). Requires explicit confirmation.")]
     public static async Task<string> Delete(
         ImmichClient client,
@@ -499,7 +499,7 @@ public static class AssetTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.assets.statistics")]
+    [McpServerTool(Name = "immich_assets_statistics")]
     [Description("Get asset statistics (count of images, videos, total).")]
     public static async Task<string> Statistics(ImmichClient client)
     {

--- a/ImmichMCP/Tools/HealthTools.cs
+++ b/ImmichMCP/Tools/HealthTools.cs
@@ -12,7 +12,7 @@ namespace ImmichMCP.Tools;
 [McpServerToolType]
 public static class HealthTools
 {
-    [McpServerTool(Name = "immich.ping")]
+    [McpServerTool(Name = "immich_ping")]
     [Description("Verify connectivity and authentication with the Immich instance. Returns server version if available.")]
     public static async Task<string> Ping(ImmichClient client)
     {
@@ -43,7 +43,7 @@ public static class HealthTools
         return JsonSerializer.Serialize(errorResponse);
     }
 
-    [McpServerTool(Name = "immich.capabilities")]
+    [McpServerTool(Name = "immich_capabilities")]
     [Description("Return supported API features and detected Immich server capabilities.")]
     public static async Task<string> GetCapabilities(ImmichClient client)
     {

--- a/ImmichMCP/Tools/PeopleTools.cs
+++ b/ImmichMCP/Tools/PeopleTools.cs
@@ -15,7 +15,7 @@ namespace ImmichMCP.Tools;
 [McpServerToolType]
 public static class PeopleTools
 {
-    [McpServerTool(Name = "immich.people.list")]
+    [McpServerTool(Name = "immich_people_list")]
     [Description("List all recognized people in the library.")]
     public static async Task<string> List(
         ImmichClient client,
@@ -72,7 +72,7 @@ public static class PeopleTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.people.get")]
+    [McpServerTool(Name = "immich_people_get")]
     [Description("Get person details by ID.")]
     public static async Task<string> Get(
         ImmichClient client,
@@ -97,7 +97,7 @@ public static class PeopleTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.people.update")]
+    [McpServerTool(Name = "immich_people_update")]
     [Description("Update person information (name, birth date, hidden status).")]
     public static async Task<string> Update(
         ImmichClient client,
@@ -138,7 +138,7 @@ public static class PeopleTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.people.merge")]
+    [McpServerTool(Name = "immich_people_merge")]
     [Description("Merge multiple people into one (for duplicate face clusters).")]
     public static async Task<string> Merge(
         ImmichClient client,
@@ -210,7 +210,7 @@ public static class PeopleTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.people.assets")]
+    [McpServerTool(Name = "immich_people_assets")]
     [Description("List assets containing a specific person.")]
     public static async Task<string> Assets(
         ImmichClient client,

--- a/ImmichMCP/Tools/SearchTools.cs
+++ b/ImmichMCP/Tools/SearchTools.cs
@@ -15,7 +15,7 @@ namespace ImmichMCP.Tools;
 [McpServerToolType]
 public static class SearchTools
 {
-    [McpServerTool(Name = "immich.search.metadata")]
+    [McpServerTool(Name = "immich_search_metadata")]
     [Description("Search assets by metadata filters (dates, type, location, camera, person, etc.).")]
     public static async Task<string> MetadataSearch(
         ImmichClient client,
@@ -76,7 +76,7 @@ public static class SearchTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.search.smart")]
+    [McpServerTool(Name = "immich_search_smart")]
     [Description("ML-based semantic search using CLIP. Search using natural language queries like 'sunset at the beach' or 'birthday cake'.")]
     public static async Task<string> SmartSearch(
         ImmichClient client,
@@ -141,7 +141,7 @@ public static class SearchTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.search.explore")]
+    [McpServerTool(Name = "immich_search_explore")]
     [Description("Get explore/discovery data showing popular places, things, and people from your library.")]
     public static async Task<string> Explore(ImmichClient client)
     {

--- a/ImmichMCP/Tools/SharedLinkTools.cs
+++ b/ImmichMCP/Tools/SharedLinkTools.cs
@@ -14,7 +14,7 @@ namespace ImmichMCP.Tools;
 [McpServerToolType]
 public static class SharedLinkTools
 {
-    [McpServerTool(Name = "immich.shared_links.list")]
+    [McpServerTool(Name = "immich_shared_links_list")]
     [Description("List all shared links.")]
     public static async Task<string> List(ImmichClient client)
     {
@@ -33,7 +33,7 @@ public static class SharedLinkTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.shared_links.get")]
+    [McpServerTool(Name = "immich_shared_links_get")]
     [Description("Get shared link by ID.")]
     public static async Task<string> Get(
         ImmichClient client,
@@ -75,7 +75,7 @@ public static class SharedLinkTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.shared_links.create")]
+    [McpServerTool(Name = "immich_shared_links_create")]
     [Description("Create a new shared link for an album or assets.")]
     public static async Task<string> Create(
         ImmichClient client,
@@ -157,7 +157,7 @@ public static class SharedLinkTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.shared_links.update")]
+    [McpServerTool(Name = "immich_shared_links_update")]
     [Description("Update shared link settings (expiry, permissions, etc.).")]
     public static async Task<string> Update(
         ImmichClient client,
@@ -213,7 +213,7 @@ public static class SharedLinkTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.shared_links.delete")]
+    [McpServerTool(Name = "immich_shared_links_delete")]
     [Description("Delete a shared link. Requires explicit confirmation.")]
     public static async Task<string> Delete(
         ImmichClient client,

--- a/ImmichMCP/Tools/TagTools.cs
+++ b/ImmichMCP/Tools/TagTools.cs
@@ -14,7 +14,7 @@ namespace ImmichMCP.Tools;
 [McpServerToolType]
 public static class TagTools
 {
-    [McpServerTool(Name = "immich.tags.list")]
+    [McpServerTool(Name = "immich_tags_list")]
     [Description("List all tags.")]
     public static async Task<string> List(ImmichClient client)
     {
@@ -33,7 +33,7 @@ public static class TagTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.tags.get")]
+    [McpServerTool(Name = "immich_tags_get")]
     [Description("Get tag by ID.")]
     public static async Task<string> Get(
         ImmichClient client,
@@ -58,7 +58,7 @@ public static class TagTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.tags.create")]
+    [McpServerTool(Name = "immich_tags_create")]
     [Description("Create a new tag.")]
     public static async Task<string> Create(
         ImmichClient client,
@@ -100,7 +100,7 @@ public static class TagTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.tags.update")]
+    [McpServerTool(Name = "immich_tags_update")]
     [Description("Update a tag.")]
     public static async Task<string> Update(
         ImmichClient client,
@@ -133,7 +133,7 @@ public static class TagTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.tags.delete")]
+    [McpServerTool(Name = "immich_tags_delete")]
     [Description("Delete a tag. Requires explicit confirmation.")]
     public static async Task<string> Delete(
         ImmichClient client,
@@ -187,7 +187,7 @@ public static class TagTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.tags.assets.add")]
+    [McpServerTool(Name = "immich_tags_assets_add")]
     [Description("Tag assets with a specific tag.")]
     public static async Task<string> TagAssets(
         ImmichClient client,
@@ -234,7 +234,7 @@ public static class TagTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.tags.assets.remove")]
+    [McpServerTool(Name = "immich_tags_assets_remove")]
     [Description("Remove tag from assets.")]
     public static async Task<string> UntagAssets(
         ImmichClient client,

--- a/ImmichMCP/Tools/UploadTools.cs
+++ b/ImmichMCP/Tools/UploadTools.cs
@@ -24,7 +24,7 @@ public class UploadTools
         _options = options.Value;
     }
 
-    [McpServerTool(Name = "immich.assets.upload_init")]
+    [McpServerTool(Name = "immich_assets_upload_init")]
     [Description("Initialize an out-of-band file upload. Returns an upload URL where you can POST the file directly. Use this for uploading files when the MCP server cannot access the local filesystem.")]
     public string UploadInit(
         ImmichClient client,
@@ -60,7 +60,7 @@ public class UploadTools
         return JsonSerializer.Serialize(response);
     }
 
-    [McpServerTool(Name = "immich.assets.upload_status")]
+    [McpServerTool(Name = "immich_assets_upload_status")]
     [Description("Check the status of an upload session.")]
     public string UploadStatus(
         ImmichClient client,

--- a/README.md
+++ b/README.md
@@ -100,86 +100,86 @@ Or with Docker:
 
 | Tool | Description |
 |------|-------------|
-| `immich.ping` | Verify connectivity and return server version |
-| `immich.capabilities` | List available API features |
+| `immich_ping` | Verify connectivity and return server version |
+| `immich_capabilities` | List available API features |
 
 ### Assets
 
 | Tool | Description |
 |------|-------------|
-| `immich.assets.list` | List recent assets with filters |
-| `immich.assets.get` | Get full asset metadata |
-| `immich.assets.exif` | Get EXIF data for an asset |
-| `immich.assets.download.original` | Get download URL for original |
-| `immich.assets.download.thumbnail` | Get thumbnail/preview URLs |
-| `immich.assets.upload` | Upload asset (base64) |
-| `immich.assets.upload_from_path` | Upload from local file path |
-| `immich.assets.update` | Update asset metadata |
-| `immich.assets.bulk_update` | Bulk update multiple assets |
-| `immich.assets.delete` | Delete asset(s) |
-| `immich.assets.statistics` | Get asset statistics |
+| `immich_assets_list` | List recent assets with filters |
+| `immich_assets_get` | Get full asset metadata |
+| `immich_assets_exif` | Get EXIF data for an asset |
+| `immich_assets_download_original` | Get download URL for original |
+| `immich_assets_download_thumbnail` | Get thumbnail/preview URLs |
+| `immich_assets_upload` | Upload asset (base64) |
+| `immich_assets_upload_from_path` | Upload from local file path |
+| `immich_assets_update` | Update asset metadata |
+| `immich_assets_bulk_update` | Bulk update multiple assets |
+| `immich_assets_delete` | Delete asset(s) |
+| `immich_assets_statistics` | Get asset statistics |
 
 ### Search
 
 | Tool | Description |
 |------|-------------|
-| `immich.search.metadata` | Search by metadata filters |
-| `immich.search.smart` | ML-based semantic search (CLIP) |
-| `immich.search.explore` | Get explore/discovery data |
+| `immich_search_metadata` | Search by metadata filters |
+| `immich_search_smart` | ML-based semantic search (CLIP) |
+| `immich_search_explore` | Get explore/discovery data |
 
 ### Albums
 
 | Tool | Description |
 |------|-------------|
-| `immich.albums.list` | List all albums |
-| `immich.albums.get` | Get album details |
-| `immich.albums.create` | Create new album |
-| `immich.albums.update` | Update album metadata |
-| `immich.albums.assets.add` | Add assets to album |
-| `immich.albums.assets.remove` | Remove assets from album |
-| `immich.albums.delete` | Delete album |
-| `immich.albums.statistics` | Get album statistics |
+| `immich_albums_list` | List all albums |
+| `immich_albums_get` | Get album details |
+| `immich_albums_create` | Create new album |
+| `immich_albums_update` | Update album metadata |
+| `immich_albums_assets_add` | Add assets to album |
+| `immich_albums_assets_remove` | Remove assets from album |
+| `immich_albums_delete` | Delete album |
+| `immich_albums_statistics` | Get album statistics |
 
 ### People
 
 | Tool | Description |
 |------|-------------|
-| `immich.people.list` | List all recognized people |
-| `immich.people.get` | Get person details |
-| `immich.people.update` | Update person info |
-| `immich.people.merge` | Merge duplicate people |
-| `immich.people.assets` | List assets for a person |
+| `immich_people_list` | List all recognized people |
+| `immich_people_get` | Get person details |
+| `immich_people_update` | Update person info |
+| `immich_people_merge` | Merge duplicate people |
+| `immich_people_assets` | List assets for a person |
 
 ### Tags
 
 | Tool | Description |
 |------|-------------|
-| `immich.tags.list` | List all tags |
-| `immich.tags.get` | Get tag by ID |
-| `immich.tags.create` | Create new tag |
-| `immich.tags.update` | Update tag |
-| `immich.tags.delete` | Delete tag |
-| `immich.tags.assets.add` | Tag assets |
-| `immich.tags.assets.remove` | Remove tag from assets |
+| `immich_tags_list` | List all tags |
+| `immich_tags_get` | Get tag by ID |
+| `immich_tags_create` | Create new tag |
+| `immich_tags_update` | Update tag |
+| `immich_tags_delete` | Delete tag |
+| `immich_tags_assets_add` | Tag assets |
+| `immich_tags_assets_remove` | Remove tag from assets |
 
 ### Shared Links
 
 | Tool | Description |
 |------|-------------|
-| `immich.shared_links.list` | List all shared links |
-| `immich.shared_links.get` | Get shared link details |
-| `immich.shared_links.create` | Create shared link |
-| `immich.shared_links.update` | Update shared link |
-| `immich.shared_links.delete` | Delete shared link |
+| `immich_shared_links_list` | List all shared links |
+| `immich_shared_links_get` | Get shared link details |
+| `immich_shared_links_create` | Create shared link |
+| `immich_shared_links_update` | Update shared link |
+| `immich_shared_links_delete` | Delete shared link |
 
 ### Activities
 
 | Tool | Description |
 |------|-------------|
-| `immich.activities.list` | List comments/likes |
-| `immich.activities.create` | Add comment or like |
-| `immich.activities.delete` | Delete activity |
-| `immich.activities.statistics` | Get activity statistics |
+| `immich_activities_list` | List comments/likes |
+| `immich_activities_create` | Add comment or like |
+| `immich_activities_delete` | Delete activity |
+| `immich_activities_statistics` | Get activity statistics |
 
 ## Example Usage
 


### PR DESCRIPTION
Fixes #4

## Problem

All 47 Immich tool names used dots as separators (e.g. `immich.ping`, `immich.search.metadata`), which violates the MCP specification pattern `^[a-zA-Z0-9_-]{1,64}$`. The Claude Desktop app now enforces this strictly, producing:

```
tools.36.FrontendRemoteMcpToolDefinition.name: String should match pattern '^[a-zA-Z0-9_-]{1,64}$'
```

This prevents the server from loading at all in affected clients.

## Fix

Replace dots with underscores in all tool `Name` attributes across the 9 tool files, and update the README accordingly.

**Examples:**
| Before | After |
|--------|-------|
| `immich.ping` | `immich_ping` |
| `immich.search.metadata` | `immich_search_metadata` |
| `immich.albums.assets.add` | `immich_albums_assets_add` |

## Notes

- This is a breaking change for any clients that reference tool names directly
- All 47 tools renamed; no functional changes