### PR TITLE
fix: include EXIF data in metadata search results

### DIFF
--- a/ImmichMCP.Tests/Client/ImmichClientSearchTests.cs
+++ b/ImmichMCP.Tests/Client/ImmichClientSearchTests.cs
@@ -67,6 +67,41 @@ public class ImmichClientSearchTests
     }
 
     [Fact]
+    public async Task SearchMetadataAsync_SendsWithExifTrue_InRequestBody()
+    {
+        // Arrange
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        var searchResult = new
+        {
+            assets = new
+            {
+                total = 1,
+                count = 1,
+                items = new[] { TestFixtures.CreateAsset(id: "asset-1") },
+                nextPage = (string?)null
+            }
+        };
+
+        string? capturedRequestBody = null;
+        handler.When(HttpMethod.Post, "*/search/metadata")
+            .With(req =>
+            {
+                capturedRequestBody = req.Content!.ReadAsStringAsync().Result;
+                return true;
+            })
+            .Respond("application/json", TestFixtures.ToJson(searchResult));
+
+        var request = new MetadataSearchRequest { WithExif = true };
+
+        // Act
+        await client.SearchMetadataAsync(request);
+
+        // Assert
+        capturedRequestBody.Should().NotBeNull();
+        capturedRequestBody.Should().Contain("\"withExif\":true");
+    }
+
+    [Fact]
     public async Task SmartSearchAsync_ReturnsResults_WhenSuccessful()
     {
         // Arrange

--- a/ImmichMCP.Tests/Tools/SearchToolsTests.cs
+++ b/ImmichMCP.Tests/Tools/SearchToolsTests.cs
@@ -1,0 +1,71 @@
+using System.Net;
+using FluentAssertions;
+using RichardSzalay.MockHttp;
+using ImmichMCP.Tools;
+using ImmichMCP.Tests.Fixtures;
+
+namespace ImmichMCP.Tests.Tools;
+
+public class SearchToolsTests
+{
+    [Fact]
+    public async Task MetadataSearch_SetsWithExifTrue_InRequest()
+    {
+        // Arrange
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        var searchResult = new
+        {
+            assets = new
+            {
+                total = 1,
+                count = 1,
+                items = new[] { TestFixtures.CreateAsset(id: "asset-1") },
+                nextPage = (string?)null
+            }
+        };
+
+        string? capturedRequestBody = null;
+        handler.When(HttpMethod.Post, "*/search/metadata")
+            .With(req =>
+            {
+                capturedRequestBody = req.Content!.ReadAsStringAsync().Result;
+                return true;
+            })
+            .Respond("application/json", TestFixtures.ToJson(searchResult));
+
+        // Act
+        var result = await SearchTools.MetadataSearch(client);
+
+        // Assert
+        capturedRequestBody.Should().NotBeNull();
+        capturedRequestBody.Should().Contain("\"withExif\":true",
+            "MetadataSearch should always request EXIF data from the Immich API");
+    }
+
+    [Fact]
+    public async Task MetadataSearch_ReturnsExifData_InResults()
+    {
+        // Arrange
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        var searchResult = new
+        {
+            assets = new
+            {
+                total = 1,
+                count = 1,
+                items = new[] { TestFixtures.CreateAsset(id: "asset-1") },
+                nextPage = (string?)null
+            }
+        };
+
+        handler.When(HttpMethod.Post, "*/search/metadata")
+            .Respond("application/json", TestFixtures.ToJson(searchResult));
+
+        // Act
+        var result = await SearchTools.MetadataSearch(client);
+
+        // Assert - the result should contain EXIF fields from the fixture (Canon EOS R5)
+        result.Should().Contain("Canon");
+        result.Should().Contain("EOS R5");
+    }
+}

--- a/ImmichMCP/Tools/SearchTools.cs
+++ b/ImmichMCP/Tools/SearchTools.cs
@@ -55,7 +55,8 @@ public static class SearchTools
             LensModel = lensModel,
             PersonIds = ParseStringArray(personIds),
             OriginalFileName = originalFileName,
-            Order = order
+            Order = order,
+            WithExif = true
         };
 
         var result = await client.SearchMetadataAsync(request).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- Set `WithExif = true` in `MetadataSearchRequest` so the Immich API returns EXIF fields (city, country, camera make/model) in metadata search results
- Previously these fields were always `null` because the API defaults to excluding EXIF data unless explicitly requested

Fixes #1

## Test plan
- [x] Added `SearchToolsTests.MetadataSearch_SetsWithExifTrue_InRequest` — verifies `withExif: true` is sent in the HTTP request body
- [x] Added `SearchToolsTests.MetadataSearch_ReturnsExifData_InResults` — verifies EXIF fields appear in serialized output
- [x] Added `ImmichClientSearchTests.SearchMetadataAsync_SendsWithExifTrue_InRequestBody` — verifies at the client layer
- [x] Full test suite passes (34/34)

🤖 Generated with [Claude Code](https://claude.com/claude-code)