### PR TITLE
Add immich.search.ocr tool for Immich 2.2+ OCR text search

### DIFF
--- a/ImmichMCP.Tests/Tools/SearchToolsTests.cs
+++ b/ImmichMCP.Tests/Tools/SearchToolsTests.cs
@@ -86,7 +86,7 @@ public class SearchToolsTests
         };
 
         string? capturedRequestBody = null;
-        handler.When(HttpMethod.Post, "*/search/smart")
+        handler.When(HttpMethod.Post, "*/search/metadata")
             .With(req =>
             {
                 capturedRequestBody = req.Content!.ReadAsStringAsync().Result;
@@ -102,7 +102,7 @@ public class SearchToolsTests
         capturedRequestBody.Should().Contain("\"ocr\":\"factuur 2026\"",
             "OcrSearch must forward the text under the 'ocr' field");
         capturedRequestBody.Should().NotContain("\"query\"",
-            "OcrSearch should not send a CLIP query");
+            "OcrSearch must use the metadata endpoint, which has no CLIP query");
     }
 
     [Fact]

--- a/ImmichMCP.Tests/Tools/SearchToolsTests.cs
+++ b/ImmichMCP.Tests/Tools/SearchToolsTests.cs
@@ -68,4 +68,53 @@ public class SearchToolsTests
         result.Should().Contain("Canon");
         result.Should().Contain("EOS R5");
     }
+
+    [Fact]
+    public async Task OcrSearch_SendsOcrField_AndOmitsQuery()
+    {
+        // Arrange
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        var searchResult = new
+        {
+            assets = new
+            {
+                total = 1,
+                count = 1,
+                items = new[] { TestFixtures.CreateAsset(id: "asset-1") },
+                nextPage = (string?)null
+            }
+        };
+
+        string? capturedRequestBody = null;
+        handler.When(HttpMethod.Post, "*/search/smart")
+            .With(req =>
+            {
+                capturedRequestBody = req.Content!.ReadAsStringAsync().Result;
+                return true;
+            })
+            .Respond("application/json", TestFixtures.ToJson(searchResult));
+
+        // Act
+        var result = await SearchTools.OcrSearch(client, text: "factuur 2026");
+
+        // Assert
+        capturedRequestBody.Should().NotBeNull();
+        capturedRequestBody.Should().Contain("\"ocr\":\"factuur 2026\"",
+            "OcrSearch must forward the text under the 'ocr' field");
+        capturedRequestBody.Should().NotContain("\"query\"",
+            "OcrSearch should not send a CLIP query");
+    }
+
+    [Fact]
+    public async Task OcrSearch_ReturnsValidationError_WhenTextEmpty()
+    {
+        // Arrange
+        var (client, _) = MockHttpClientFactory.CreateMockClient();
+
+        // Act
+        var result = await SearchTools.OcrSearch(client, text: "  ");
+
+        // Assert
+        result.Should().Contain("OCR search text is required");
+    }
 }

--- a/ImmichMCP/Models/Search/SearchResult.cs
+++ b/ImmichMCP/Models/Search/SearchResult.cs
@@ -113,7 +113,7 @@ public record MetadataSearchRequest
 public record SmartSearchRequest
 {
     [JsonPropertyName("query")]
-    public string Query { get; init; } = string.Empty;
+    public string? Query { get; init; }
 
     [JsonPropertyName("page")]
     public int? Page { get; init; }
@@ -159,6 +159,9 @@ public record SmartSearchRequest
 
     [JsonPropertyName("personIds")]
     public string[]? PersonIds { get; init; }
+
+    [JsonPropertyName("ocr")]
+    public string? Ocr { get; init; }
 }
 
 /// <summary>

--- a/ImmichMCP/Models/Search/SearchResult.cs
+++ b/ImmichMCP/Models/Search/SearchResult.cs
@@ -105,6 +105,9 @@ public record MetadataSearchRequest
 
     [JsonPropertyName("order")]
     public string? Order { get; init; }
+
+    [JsonPropertyName("ocr")]
+    public string? Ocr { get; init; }
 }
 
 /// <summary>
@@ -113,7 +116,7 @@ public record MetadataSearchRequest
 public record SmartSearchRequest
 {
     [JsonPropertyName("query")]
-    public string? Query { get; init; }
+    public string Query { get; init; } = string.Empty;
 
     [JsonPropertyName("page")]
     public int? Page { get; init; }
@@ -159,9 +162,6 @@ public record SmartSearchRequest
 
     [JsonPropertyName("personIds")]
     public string[]? PersonIds { get; init; }
-
-    [JsonPropertyName("ocr")]
-    public string? Ocr { get; init; }
 }
 
 /// <summary>

--- a/ImmichMCP/Tools/SearchTools.cs
+++ b/ImmichMCP/Tools/SearchTools.cs
@@ -142,6 +142,71 @@ public static class SearchTools
         return JsonSerializer.Serialize(response);
     }
 
+    [McpServerTool(Name = "immich.search.ocr")]
+    [Description("OCR search: find assets by text recognised inside images (signs, documents, receipts, screenshots). Requires Immich 2.2+ with OCR enabled on the ML container.")]
+    public static async Task<string> OcrSearch(
+        ImmichClient client,
+        [Description("Text to search for inside images (case-insensitive substring/full-text match against the OCR index)")] string text,
+        [Description("Page number (default: 1)")] int page = 1,
+        [Description("Page size (default: 25, max: 100)")] int size = 25,
+        [Description("Asset type: IMAGE, VIDEO, or ALL")] string? type = null,
+        [Description("Filter by favorite status")] bool? isFavorite = null,
+        [Description("Filter by archived status")] bool? isArchived = null,
+        [Description("Filter assets taken after this date (YYYY-MM-DD)")] string? takenAfter = null,
+        [Description("Filter assets taken before this date (YYYY-MM-DD)")] string? takenBefore = null,
+        [Description("Filter by city")] string? city = null,
+        [Description("Filter by state/province")] string? state = null,
+        [Description("Filter by country")] string? country = null,
+        [Description("Filter by camera make")] string? make = null,
+        [Description("Filter by camera model")] string? model = null,
+        [Description("Filter by person IDs (comma-separated UUIDs)")] string? personIds = null)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            var errorResponse = McpErrorResponse.Create(
+                ErrorCodes.Validation,
+                "OCR search text is required",
+                meta: new McpMeta { ImmichBaseUrl = client.BaseUrl }
+            );
+            return JsonSerializer.Serialize(errorResponse);
+        }
+
+        var request = new SmartSearchRequest
+        {
+            Ocr = text,
+            Page = page,
+            Size = Math.Min(size, 100),
+            Type = type?.ToUpperInvariant(),
+            IsFavorite = isFavorite,
+            IsArchived = isArchived,
+            TakenAfter = ParseDate(takenAfter),
+            TakenBefore = ParseDate(takenBefore),
+            City = city,
+            State = state,
+            Country = country,
+            Make = make,
+            Model = model,
+            PersonIds = ParseStringArray(personIds)
+        };
+
+        var result = await client.SearchSmartAsync(request).ConfigureAwait(false);
+
+        var summaries = result.Items.Select(AssetSummary.FromAsset).ToList();
+
+        var response = McpResponse<object>.Success(
+            summaries,
+            new McpMeta
+            {
+                Page = page,
+                PageSize = size,
+                Total = result.Total,
+                Next = result.NextPage,
+                ImmichBaseUrl = client.BaseUrl
+            }
+        );
+        return JsonSerializer.Serialize(response);
+    }
+
     [McpServerTool(Name = "immich.search.explore")]
     [Description("Get explore/discovery data showing popular places, things, and people from your library.")]
     public static async Task<string> Explore(ImmichClient client)

--- a/ImmichMCP/Tools/SearchTools.cs
+++ b/ImmichMCP/Tools/SearchTools.cs
@@ -171,7 +171,7 @@ public static class SearchTools
             return JsonSerializer.Serialize(errorResponse);
         }
 
-        var request = new SmartSearchRequest
+        var request = new MetadataSearchRequest
         {
             Ocr = text,
             Page = page,
@@ -186,10 +186,11 @@ public static class SearchTools
             Country = country,
             Make = make,
             Model = model,
-            PersonIds = ParseStringArray(personIds)
+            PersonIds = ParseStringArray(personIds),
+            WithExif = true
         };
 
-        var result = await client.SearchSmartAsync(request).ConfigureAwait(false);
+        var result = await client.SearchMetadataAsync(request).ConfigureAwait(false);
 
         var summaries = result.Items.Select(AssetSummary.FromAsset).ToList();
 


### PR DESCRIPTION
## Summary
- New MCP tool `immich_search_ocr` that hits `POST /api/search/metadata` with the `ocr` filter for Immich 2.2+ OCR text search.
- Adds `Ocr` on `MetadataSearchRequest` so OCR search does not require a CLIP query.
- Keeps the new tool aligned with the underscore-only tool naming used by the rest of the server.
- Adds tests for payload shape and empty-text validation.

## Why a separate tool
Keeps CLIP semantic search and OCR text search discoverable as distinct capabilities for the model. OCR goes through `/api/search/metadata` because the smart endpoint requires `query` or `queryAssetId`.

## Test plan
- [x] `dotnet test` passes locally on .NET 10 SDK (36/36).
- [x] Verified the request payload uses `{"ocr":"..."}` against the metadata endpoint without sending `query`.