### PR TITLE
Fix v3 date search + never swallow errors, add authorized direct upload

### DIFF
--- a/ImmichMCP.Tests/Client/ImmichClientAlbumTests.cs
+++ b/ImmichMCP.Tests/Client/ImmichClientAlbumTests.cs
@@ -1,12 +1,28 @@
 using System.Net;
 using FluentAssertions;
 using RichardSzalay.MockHttp;
+using ImmichMCP.Client;
 using ImmichMCP.Tests.Fixtures;
 
 namespace ImmichMCP.Tests.Client;
 
 public class ImmichClientAlbumTests
 {
+    [Fact]
+    public async Task GetAlbumAsync_Throws_OnServerError_NotSwallowedAsNotFound()
+    {
+        // A 404 is a legitimate "not found" (returns null); any OTHER error must surface,
+        // not be swallowed into null and mislabelled as NOT_FOUND.
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        handler.When(HttpMethod.Get, "*/albums/boom")
+            .Respond(HttpStatusCode.InternalServerError, "text/plain", "kaboom");
+
+        var act = () => client.GetAlbumAsync("boom");
+
+        var ex = await act.Should().ThrowAsync<ImmichApiException>();
+        ex.Which.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+    }
+
     [Fact]
     public async Task GetAlbumsAsync_ReturnsAlbums_WhenSuccessful()
     {

--- a/ImmichMCP.Tests/Client/ImmichClientSearchTests.cs
+++ b/ImmichMCP.Tests/Client/ImmichClientSearchTests.cs
@@ -1,8 +1,10 @@
 using System.Net;
 using FluentAssertions;
 using RichardSzalay.MockHttp;
+using ImmichMCP.Client;
 using ImmichMCP.Models.Search;
 using ImmichMCP.Tests.Fixtures;
+using static ImmichMCP.Utils.ParsingHelpers;
 
 namespace ImmichMCP.Tests.Client;
 
@@ -99,6 +101,62 @@ public class ImmichClientSearchTests
         // Assert
         capturedRequestBody.Should().NotBeNull();
         capturedRequestBody.Should().Contain("\"withExif\":true");
+    }
+
+    [Fact]
+    public async Task SearchMetadataAsync_SerializesDates_WithTimezoneSuffix_ForImmichV3()
+    {
+        // Immich v3 validates datetime fields with Zod (z.iso.datetime), which REQUIRES
+        // a timezone designator (Z or +/-hh:mm). A bare "2026-06-02T00:00:00" is rejected
+        // with HTTP 400, which the client would swallow into an empty result set.
+        // See: POST /search/metadata returns 400 "expected ISO 8601 datetime string".
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        var searchResult = new
+        {
+            assets = new { total = 0, count = 0, items = Array.Empty<object>(), nextPage = (string?)null }
+        };
+
+        string? capturedRequestBody = null;
+        handler.When(HttpMethod.Post, "*/search/metadata")
+            .With(req =>
+            {
+                capturedRequestBody = req.Content!.ReadAsStringAsync().Result;
+                return true;
+            })
+            .Respond("application/json", TestFixtures.ToJson(searchResult));
+
+        // ParseDate("2026-06-02") yields a Kind=Unspecified DateTime, which System.Text.Json
+        // serializes with no timezone suffix unless a converter enforces one.
+        var request = new MetadataSearchRequest
+        {
+            TakenAfter = ParseDate("2026-06-02"),
+            TakenBefore = ParseDate("2026-07-02")
+        };
+
+        // Act
+        await client.SearchMetadataAsync(request);
+
+        // Assert: every serialized datetime must end in Z or an offset (Immich v3 requirement).
+        capturedRequestBody.Should().NotBeNull();
+        capturedRequestBody.Should().MatchRegex("\"takenAfter\":\"[^\"]+(Z|[+-]\\d\\d:\\d\\d)\"");
+        capturedRequestBody.Should().MatchRegex("\"takenBefore\":\"[^\"]+(Z|[+-]\\d\\d:\\d\\d)\"");
+    }
+
+    [Fact]
+    public async Task SearchMetadataAsync_Throws_OnUpstreamError_InsteadOfEmptyResult()
+    {
+        // The core bug: an upstream failure (e.g. a 400 from Immich v3 rejecting a filter)
+        // must NOT be swallowed into a successful-looking empty result. It must surface.
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        handler.When(HttpMethod.Post, "*/search/metadata")
+            .Respond(HttpStatusCode.BadRequest, "application/json",
+                "{\"message\":\"Validation failed\",\"errors\":[{\"path\":[\"takenAfter\"]}]}");
+
+        var act = () => client.SearchMetadataAsync(new MetadataSearchRequest());
+
+        var ex = await act.Should().ThrowAsync<ImmichApiException>();
+        ex.Which.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        ex.Which.ResponseBody.Should().Contain("Validation failed");
     }
 
     [Fact]

--- a/ImmichMCP.Tests/Gateway/ImmichToolGatewayErrorHandlingTests.cs
+++ b/ImmichMCP.Tests/Gateway/ImmichToolGatewayErrorHandlingTests.cs
@@ -1,0 +1,72 @@
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using ImmichMCP.Client;
+using ImmichMCP.Tools.Gateway;
+using ModelContextProtocol.Protocol;
+
+namespace ImmichMCP.Tests.Gateway;
+
+/// <summary>
+/// The MCP spec requires tool execution errors to be reported with isError: true.
+/// These guard the gateway boundary that enforces that for both thrown upstream
+/// failures and tool-serialized {"ok": false} envelopes.
+/// </summary>
+public class ImmichToolGatewayErrorHandlingTests
+{
+    [Theory]
+    [InlineData("{\"ok\":false,\"error\":{\"code\":\"NOT_FOUND\"}}", true)]
+    [InlineData("{\"ok\":true,\"result\":[]}", false)]
+    [InlineData("{\"result\":[]}", false)]
+    [InlineData("not json", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void IsErrorEnvelope_DetectsOkFalse(string? text, bool expected)
+    {
+        ImmichToolGateway.IsErrorEnvelope(text).Should().Be(expected);
+    }
+
+    [Fact]
+    public void MarkErrorEnvelope_FlagsIsError_ForOkFalseEnvelope()
+    {
+        var result = new CallToolResult
+        {
+            Content = [new TextContentBlock { Text = "{\"ok\":false,\"error\":{\"code\":\"UPSTREAM_ERROR\"}}" }],
+            IsError = false
+        };
+
+        ImmichToolGateway.MarkErrorEnvelope(result).IsError.Should().BeTrue();
+    }
+
+    [Fact]
+    public void MarkErrorEnvelope_LeavesSuccess_Untouched()
+    {
+        var result = new CallToolResult
+        {
+            Content = [new TextContentBlock { Text = "{\"ok\":true,\"result\":[]}" }],
+            IsError = false
+        };
+
+        ImmichToolGateway.MarkErrorEnvelope(result).IsError.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.Unauthorized, "AUTH_FAILED")]
+    [InlineData(HttpStatusCode.Forbidden, "AUTH_FAILED")]
+    [InlineData(HttpStatusCode.NotFound, "NOT_FOUND")]
+    [InlineData(HttpStatusCode.BadRequest, "VALIDATION")]
+    [InlineData(HttpStatusCode.UnprocessableEntity, "VALIDATION")]
+    [InlineData(HttpStatusCode.TooManyRequests, "RATE_LIMIT")]
+    [InlineData(HttpStatusCode.InternalServerError, "UPSTREAM_ERROR")]
+    [InlineData(HttpStatusCode.BadGateway, "UPSTREAM_ERROR")]
+    public void BuildUpstreamError_MapsStatusToErrorCode(HttpStatusCode status, string expectedCode)
+    {
+        var ex = new ImmichApiException(status, "GET", "api/thing", "body");
+
+        var json = JsonSerializer.SerializeToElement(ImmichToolGateway.BuildUpstreamError(ex));
+
+        json.GetProperty("ok").GetBoolean().Should().BeFalse();
+        json.GetProperty("error").GetProperty("code").GetString().Should().Be(expectedCode);
+        json.GetProperty("error").GetProperty("details").GetProperty("status").GetInt32().Should().Be((int)status);
+    }
+}

--- a/ImmichMCP.Tests/Gateway/ImmichToolGatewayTests.cs
+++ b/ImmichMCP.Tests/Gateway/ImmichToolGatewayTests.cs
@@ -15,7 +15,7 @@ public class ImmichToolGatewayTests
         using var services = CreateServices();
         var registry = services.GetRequiredService<ImmichToolRegistry>();
 
-        registry.Tools.Should().HaveCount(48);
+        registry.Tools.Should().HaveCount(49);
         registry.Categories.Should().BeEquivalentTo(
             "activities",
             "albums",

--- a/ImmichMCP.Tests/Integration/ImmichApiIntegrationTests.cs
+++ b/ImmichMCP.Tests/Integration/ImmichApiIntegrationTests.cs
@@ -1,5 +1,8 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
 using FluentAssertions;
 using ImmichMCP.Models.Search;
+using ImmichMCP.Tools;
 
 namespace ImmichMCP.Tests.Integration;
 
@@ -50,6 +53,39 @@ public class ImmichApiIntegrationTests
         asset.Id.Should().NotBeNullOrWhiteSpace();
         asset.Type.Should().NotBeNullOrWhiteSpace();
         asset.Visibility.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [IntegrationFact]
+    public async Task MetadataSearch_WithTakenAfterFilter_ReturnsResults()
+    {
+        // Regression: Immich v3 validates datetime fields with Zod, rejecting datetimes
+        // without a timezone designator (HTTP 400), which the client swallowed into an
+        // empty result. This exercises the real takenAfter path end-to-end.
+        var settings = IntegrationTestSettings.Load();
+        var client = settings.CreateClient();
+
+        // Find the newest asset to derive a date window that is guaranteed to contain data.
+        var newest = await client.SearchMetadataAsync(new MetadataSearchRequest { Size = 1, Order = "desc" });
+        var anchor = newest.Items.FirstOrDefault();
+        if (anchor == null)
+        {
+            return; // empty library — nothing to assert
+        }
+
+        // A window starting just before the newest asset must return at least that asset.
+        var withinWindow = await client.SearchMetadataAsync(new MetadataSearchRequest
+        {
+            TakenAfter = anchor.FileCreatedAt.AddDays(-1),
+            Order = "desc"
+        });
+        withinWindow.Items.Should().NotBeEmpty("takenAfter must be accepted by Immich v3, not rejected into an empty result");
+
+        // A window far in the future must return nothing — proving the filter is applied, not ignored.
+        var future = await client.SearchMetadataAsync(new MetadataSearchRequest
+        {
+            TakenAfter = anchor.FileCreatedAt.AddYears(50)
+        });
+        future.Items.Should().BeEmpty("takenAfter must actually constrain results");
     }
 
     [IntegrationFact]
@@ -115,6 +151,58 @@ public class ImmichApiIntegrationTests
                 var deleted = await client.DeleteAssetsAsync([uploadedAssetId], force: true);
                 deleted.Should().BeTrue("the integration upload should be removed from Immich");
             }
+        }
+    }
+
+    [MutationIntegrationFact]
+    public async Task AuthorizeUpload_MintsTokenThatUploadsIntoAlbum_WithoutApiKey()
+    {
+        var settings = IntegrationTestSettings.Load();
+        var client = settings.CreateClient();
+
+        string? albumId = null, linkId = null, assetId = null;
+        try
+        {
+            // 1. The tool mints an album + upload-only shared-link URL using the master key.
+            var json = await AssetTools.AuthorizeUpload(client, albumName: $"mcp-auth-upload-{Guid.NewGuid():N}");
+            using var doc = JsonDocument.Parse(json);
+            doc.RootElement.GetProperty("ok").GetBoolean().Should().BeTrue(json);
+            var result = doc.RootElement.GetProperty("result");
+            var uploadUrl = result.GetProperty("upload_url").GetString()!;
+            albumId = result.GetProperty("album_id").GetString();
+            linkId = result.GetProperty("shared_link_id").GetString();
+            uploadUrl.Should().Contain("?key=");
+
+            // 2. Upload with ONLY the token — a bare client, no x-api-key header.
+            using var http = new HttpClient();
+            using var form = new MultipartFormDataContent();
+            var file = new ByteArrayContent(OnePixelPng);
+            file.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+            form.Add(file, "assetData", "auth-upload.png");
+            var ts = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+            form.Add(new StringContent(ts), "fileCreatedAt");
+            form.Add(new StringContent(ts), "fileModifiedAt");
+            form.Add(new StringContent("mcp-test-device"), "deviceId");
+            form.Add(new StringContent($"auth-upload-{Guid.NewGuid():N}"), "deviceAssetId");
+
+            var resp = await http.PostAsync(uploadUrl, form);
+            resp.IsSuccessStatusCode.Should().BeTrue($"token-only upload should succeed, got {(int)resp.StatusCode}");
+            using var body = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+            assetId = body.RootElement.GetProperty("id").GetString();
+            body.RootElement.GetProperty("status").GetString().Should().BeOneOf("created", "duplicate");
+
+            // 3. It landed in the album the tool created.
+            var album = await client.GetAlbumAsync(albumId!);
+            album!.AssetCount.Should().BeGreaterThanOrEqualTo(1);
+        }
+        finally
+        {
+            if (!string.IsNullOrWhiteSpace(assetId))
+                await client.DeleteAssetsAsync([assetId], force: true);
+            if (!string.IsNullOrWhiteSpace(linkId))
+                await client.DeleteSharedLinkAsync(linkId);
+            if (!string.IsNullOrWhiteSpace(albumId))
+                await client.DeleteAlbumAsync(albumId);
         }
     }
 

--- a/ImmichMCP.Tests/Integration/ImmichMcpGatewayIntegrationTests.cs
+++ b/ImmichMCP.Tests/Integration/ImmichMcpGatewayIntegrationTests.cs
@@ -13,23 +13,7 @@ public class ImmichMcpGatewayIntegrationTests
     [McpIntegrationFact]
     public async Task GatewayModeEnablesHealthToolsAndPingsImmich()
     {
-        var endpoint = Environment.GetEnvironmentVariable("IMMICH_MCP_BASE_URL") ?? "http://127.0.0.1:5000/mcp";
-        await using var client = await McpClient.CreateAsync(
-            new HttpClientTransport(
-                new HttpClientTransportOptions
-                {
-                    Endpoint = new Uri(endpoint),
-                    Name = "immichmcp-compose-smoke"
-                },
-                NullLoggerFactory.Instance),
-            new McpClientOptions
-            {
-                ClientInfo = new Implementation
-                {
-                    Name = "immichmcp-gateway-integration-tests",
-                    Version = "1.0.0"
-                }
-            });
+        await using var client = await CreateClient();
 
         var initialTools = await client.ListToolsAsync(new ListToolsRequestParams());
         initialTools.Tools.Select(tool => tool.Name).Should().BeEquivalentTo(
@@ -54,6 +38,58 @@ public class ImmichMcpGatewayIntegrationTests
         var version = pingJson.RootElement.GetProperty("result").GetProperty("version").GetString();
         version.Should().NotBeNullOrWhiteSpace();
         version!.TrimStart('v').Should().StartWith("3.");
+    }
+
+    [McpIntegrationFact]
+    public async Task GatewayModeAdvertisesAndEmitsToolListChanged()
+    {
+        var notification = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var client = await CreateClient(new McpClientHandlers
+        {
+            NotificationHandlers = new Dictionary<string, Func<JsonRpcNotification, CancellationToken, ValueTask>>
+            {
+                [NotificationMethods.ToolListChangedNotification] = (_, _) =>
+                {
+                    notification.TrySetResult();
+                    return ValueTask.CompletedTask;
+                }
+            }
+        });
+
+        client.ServerCapabilities.Tools.Should().NotBeNull();
+        client.ServerCapabilities.Tools!.ListChanged.Should().BeTrue();
+
+        var enableResult = await client.CallToolAsync(
+            ImmichToolGateway.EnableToolsName,
+            new Dictionary<string, object?> { ["categories"] = new[] { "search" } });
+
+        enableResult.IsError.Should().NotBeTrue(GetText(enableResult));
+        await notification.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var enabledTools = await client.ListToolsAsync(new ListToolsRequestParams());
+        enabledTools.Tools.Select(tool => tool.Name).Should().Contain("immich_search_metadata");
+    }
+
+    private static async Task<McpClient> CreateClient(McpClientHandlers? handlers = null)
+    {
+        var endpoint = Environment.GetEnvironmentVariable("IMMICH_MCP_BASE_URL") ?? "http://127.0.0.1:5000/mcp";
+        return await McpClient.CreateAsync(
+            new HttpClientTransport(
+                new HttpClientTransportOptions
+                {
+                    Endpoint = new Uri(endpoint),
+                    Name = "immichmcp-compose-smoke"
+                },
+                NullLoggerFactory.Instance),
+            new McpClientOptions
+            {
+                ClientInfo = new Implementation
+                {
+                    Name = "immichmcp-gateway-integration-tests",
+                    Version = "1.0.0"
+                },
+                Handlers = handlers ?? new McpClientHandlers()
+            });
     }
 
     private static string GetText(CallToolResult result)

--- a/ImmichMCP/Client/ImmichApiException.cs
+++ b/ImmichMCP/Client/ImmichApiException.cs
@@ -1,0 +1,44 @@
+using System.Net;
+
+namespace ImmichMCP.Client;
+
+/// <summary>
+/// Thrown when the Immich API returns a non-success status (other than a legitimate
+/// 404 not-found on a get-by-id). Carries enough context for the MCP boundary to
+/// surface a spec-compliant tool execution error (a result with isError: true) instead
+/// of silently swallowing the failure into an empty or default value.
+/// </summary>
+public sealed class ImmichApiException : Exception
+{
+    public HttpStatusCode StatusCode { get; }
+    public string Method { get; }
+    public string Path { get; }
+    public string? ResponseBody { get; }
+
+    public ImmichApiException(HttpStatusCode statusCode, string method, string path, string? responseBody)
+        : base($"Immich API {method} {path} failed with HTTP {(int)statusCode}: {Summarize(responseBody)}")
+    {
+        StatusCode = statusCode;
+        Method = method;
+        Path = path;
+        ResponseBody = responseBody;
+    }
+
+    /// <summary>
+    /// Builds an exception from a failed response, capturing its body for diagnostics.
+    /// </summary>
+    public static async Task<ImmichApiException> FromResponseAsync(
+        HttpResponseMessage response, string method, string path, CancellationToken cancellationToken)
+    {
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        return new ImmichApiException(response.StatusCode, method, path, body);
+    }
+
+    private static string Summarize(string? body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+            return "(no response body)";
+
+        return body.Length > 500 ? body[..500] + "…" : body;
+    }
+}

--- a/ImmichMCP/Client/ImmichClient.cs
+++ b/ImmichMCP/Client/ImmichClient.cs
@@ -31,7 +31,8 @@ public class ImmichClient
     {
         PropertyNameCaseInsensitive = true,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        Converters = { new Utils.UtcIsoDateTimeConverter() }
     };
 
     public ImmichClient(HttpClient httpClient, IOptions<ImmichOptions> options, ILogger<ImmichClient> logger)
@@ -146,16 +147,14 @@ public class ImmichClient
     /// </summary>
     public async Task<bool> BulkUpdateAssetsAsync(AssetBulkUpdateRequest request, CancellationToken cancellationToken = default)
     {
-        try
+        var response = await _httpClient.PutAsJsonAsync("api/assets", request, JsonOptions, cancellationToken).ConfigureAwait(false);
+
+        if (response.IsSuccessStatusCode)
         {
-            var response = await _httpClient.PutAsJsonAsync("api/assets", request, JsonOptions, cancellationToken).ConfigureAwait(false);
-            return response.IsSuccessStatusCode;
+            return true;
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to bulk update assets");
-            return false;
-        }
+
+        throw await ImmichApiException.FromResponseAsync(response, "PUT", "api/assets", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -163,20 +162,18 @@ public class ImmichClient
     /// </summary>
     public async Task<bool> DeleteAssetsAsync(string[] ids, bool force = false, CancellationToken cancellationToken = default)
     {
-        try
+        var request = new HttpRequestMessage(HttpMethod.Delete, "api/assets")
         {
-            var request = new HttpRequestMessage(HttpMethod.Delete, "api/assets")
-            {
-                Content = JsonContent.Create(new { ids, force }, options: JsonOptions)
-            };
-            var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
-            return response.IsSuccessStatusCode || response.StatusCode == HttpStatusCode.NoContent;
-        }
-        catch (Exception ex)
+            Content = JsonContent.Create(new { ids, force }, options: JsonOptions)
+        };
+        var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        if (response.IsSuccessStatusCode || response.StatusCode == HttpStatusCode.NoContent)
         {
-            _logger.LogError(ex, "Failed to delete assets");
-            return false;
+            return true;
         }
+
+        throw await ImmichApiException.FromResponseAsync(response, "DELETE", "api/assets", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -329,24 +326,15 @@ public class ImmichClient
         MetadataSearchRequest request,
         CancellationToken cancellationToken = default)
     {
-        try
-        {
-            var response = await _httpClient.PostAsJsonAsync("api/search/metadata", request, JsonOptions, cancellationToken).ConfigureAwait(false);
+        var response = await _httpClient.PostAsJsonAsync("api/search/metadata", request, JsonOptions, cancellationToken).ConfigureAwait(false);
 
-            if (response.IsSuccessStatusCode)
-            {
-                var result = await response.Content.ReadFromJsonAsync<SearchResult<Asset>>(JsonOptions, cancellationToken).ConfigureAwait(false);
-                return result?.Assets ?? new SearchAssetResult<Asset>();
-            }
-
-            await LogErrorResponse(response, "POST", "api/search/metadata").ConfigureAwait(false);
-            return new SearchAssetResult<Asset>();
-        }
-        catch (Exception ex)
+        if (response.IsSuccessStatusCode)
         {
-            _logger.LogError(ex, "Metadata search failed");
-            return new SearchAssetResult<Asset>();
+            var result = await response.Content.ReadFromJsonAsync<SearchResult<Asset>>(JsonOptions, cancellationToken).ConfigureAwait(false);
+            return result?.Assets ?? new SearchAssetResult<Asset>();
         }
+
+        throw await ImmichApiException.FromResponseAsync(response, "POST", "api/search/metadata", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -356,24 +344,15 @@ public class ImmichClient
         SmartSearchRequest request,
         CancellationToken cancellationToken = default)
     {
-        try
-        {
-            var response = await _httpClient.PostAsJsonAsync("api/search/smart", request, JsonOptions, cancellationToken).ConfigureAwait(false);
+        var response = await _httpClient.PostAsJsonAsync("api/search/smart", request, JsonOptions, cancellationToken).ConfigureAwait(false);
 
-            if (response.IsSuccessStatusCode)
-            {
-                var result = await response.Content.ReadFromJsonAsync<SearchResult<Asset>>(JsonOptions, cancellationToken).ConfigureAwait(false);
-                return result?.Assets ?? new SearchAssetResult<Asset>();
-            }
-
-            await LogErrorResponse(response, "POST", "api/search/smart").ConfigureAwait(false);
-            return new SearchAssetResult<Asset>();
-        }
-        catch (Exception ex)
+        if (response.IsSuccessStatusCode)
         {
-            _logger.LogError(ex, "Smart search failed");
-            return new SearchAssetResult<Asset>();
+            var result = await response.Content.ReadFromJsonAsync<SearchResult<Asset>>(JsonOptions, cancellationToken).ConfigureAwait(false);
+            return result?.Assets ?? new SearchAssetResult<Asset>();
         }
+
+        throw await ImmichApiException.FromResponseAsync(response, "POST", "api/search/smart", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -456,27 +435,18 @@ public class ImmichClient
     /// </summary>
     public async Task<List<BulkIdResponse>?> RemoveAssetsFromAlbumAsync(string albumId, string[] assetIds, CancellationToken cancellationToken = default)
     {
-        try
+        var request = new HttpRequestMessage(HttpMethod.Delete, $"api/albums/{albumId}/assets")
         {
-            var request = new HttpRequestMessage(HttpMethod.Delete, $"api/albums/{albumId}/assets")
-            {
-                Content = JsonContent.Create(new { ids = assetIds }, options: JsonOptions)
-            };
-            var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            Content = JsonContent.Create(new { ids = assetIds }, options: JsonOptions)
+        };
+        var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
-            if (response.IsSuccessStatusCode)
-            {
-                return await response.Content.ReadFromJsonAsync<List<BulkIdResponse>>(JsonOptions, cancellationToken).ConfigureAwait(false);
-            }
-
-            await LogErrorResponse(response, "DELETE", $"api/albums/{albumId}/assets").ConfigureAwait(false);
-            return null;
-        }
-        catch (Exception ex)
+        if (response.IsSuccessStatusCode)
         {
-            _logger.LogError(ex, "Failed to remove assets from album");
-            return null;
+            return await response.Content.ReadFromJsonAsync<List<BulkIdResponse>>(JsonOptions, cancellationToken).ConfigureAwait(false);
         }
+
+        throw await ImmichApiException.FromResponseAsync(response, "DELETE", $"api/albums/{albumId}/assets", cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -594,27 +564,18 @@ public class ImmichClient
     /// </summary>
     public async Task<List<BulkIdResponse>?> UntagAssetsAsync(string tagId, string[] assetIds, CancellationToken cancellationToken = default)
     {
-        try
+        var request = new HttpRequestMessage(HttpMethod.Delete, $"api/tags/{tagId}/assets")
         {
-            var request = new HttpRequestMessage(HttpMethod.Delete, $"api/tags/{tagId}/assets")
-            {
-                Content = JsonContent.Create(new { ids = assetIds }, options: JsonOptions)
-            };
-            var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            Content = JsonContent.Create(new { ids = assetIds }, options: JsonOptions)
+        };
+        var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
-            if (response.IsSuccessStatusCode)
-            {
-                return await response.Content.ReadFromJsonAsync<List<BulkIdResponse>>(JsonOptions, cancellationToken).ConfigureAwait(false);
-            }
-
-            await LogErrorResponse(response, "DELETE", $"api/tags/{tagId}/assets").ConfigureAwait(false);
-            return null;
-        }
-        catch (Exception ex)
+        if (response.IsSuccessStatusCode)
         {
-            _logger.LogError(ex, "Failed to untag assets");
-            return null;
+            return await response.Content.ReadFromJsonAsync<List<BulkIdResponse>>(JsonOptions, cancellationToken).ConfigureAwait(false);
         }
+
+        throw await ImmichApiException.FromResponseAsync(response, "DELETE", $"api/tags/{tagId}/assets", cancellationToken).ConfigureAwait(false);
     }
 
     #endregion
@@ -675,27 +636,18 @@ public class ImmichClient
     /// </summary>
     public async Task<List<BulkIdResponse>?> RemoveAssetsFromSharedLinkAsync(string linkId, string[] assetIds, CancellationToken cancellationToken = default)
     {
-        try
+        var request = new HttpRequestMessage(HttpMethod.Delete, $"api/shared-links/{linkId}/assets")
         {
-            var request = new HttpRequestMessage(HttpMethod.Delete, $"api/shared-links/{linkId}/assets")
-            {
-                Content = JsonContent.Create(new { ids = assetIds }, options: JsonOptions)
-            };
-            var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            Content = JsonContent.Create(new { ids = assetIds }, options: JsonOptions)
+        };
+        var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
-            if (response.IsSuccessStatusCode)
-            {
-                return await response.Content.ReadFromJsonAsync<List<BulkIdResponse>>(JsonOptions, cancellationToken).ConfigureAwait(false);
-            }
-
-            await LogErrorResponse(response, "DELETE", $"api/shared-links/{linkId}/assets").ConfigureAwait(false);
-            return null;
-        }
-        catch (Exception ex)
+        if (response.IsSuccessStatusCode)
         {
-            _logger.LogError(ex, "Failed to remove assets from shared link");
-            return null;
+            return await response.Content.ReadFromJsonAsync<List<BulkIdResponse>>(JsonOptions, cancellationToken).ConfigureAwait(false);
         }
+
+        throw await ImmichApiException.FromResponseAsync(response, "DELETE", $"api/shared-links/{linkId}/assets", cancellationToken).ConfigureAwait(false);
     }
 
     #endregion
@@ -754,117 +706,76 @@ public class ImmichClient
 
     #region HTTP Helpers
 
+    // NOTE ON ERROR HANDLING: these helpers never swallow an upstream failure into a
+    // default/empty value. On a non-success status they throw ImmichApiException so the
+    // MCP boundary can report a spec-compliant tool execution error (isError: true).
+    // The single deliberate exception is 404 on a get-by-id, which is a legitimate
+    // "not found" result the caller maps to a NOT_FOUND response.
+
     private async Task<T?> GetAsync<T>(string url, CancellationToken cancellationToken)
     {
-        try
-        {
-            var response = await _httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+        var response = await _httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
 
-            if (response.IsSuccessStatusCode)
-            {
-                return await response.Content.ReadFromJsonAsync<T>(JsonOptions, cancellationToken).ConfigureAwait(false);
-            }
-
-            await LogErrorResponse(response, "GET", url).ConfigureAwait(false);
-            return default;
-        }
-        catch (Exception ex)
+        if (response.IsSuccessStatusCode)
         {
-            _logger.LogError(ex, "GET request failed: {Url}", url);
-            return default;
+            return await response.Content.ReadFromJsonAsync<T>(JsonOptions, cancellationToken).ConfigureAwait(false);
         }
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return default; // legitimate not-found, surfaced by the tool as NOT_FOUND
+        }
+
+        throw await ImmichApiException.FromResponseAsync(response, "GET", url, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<T?> PostAsync<T>(string url, object request, CancellationToken cancellationToken)
     {
-        try
-        {
-            var response = await _httpClient.PostAsJsonAsync(url, request, JsonOptions, cancellationToken).ConfigureAwait(false);
+        var response = await _httpClient.PostAsJsonAsync(url, request, JsonOptions, cancellationToken).ConfigureAwait(false);
 
-            if (response.IsSuccessStatusCode)
-            {
-                return await response.Content.ReadFromJsonAsync<T>(JsonOptions, cancellationToken).ConfigureAwait(false);
-            }
-
-            await LogErrorResponse(response, "POST", url).ConfigureAwait(false);
-            return default;
-        }
-        catch (Exception ex)
+        if (response.IsSuccessStatusCode)
         {
-            _logger.LogError(ex, "POST request failed: {Url}", url);
-            return default;
+            return await response.Content.ReadFromJsonAsync<T>(JsonOptions, cancellationToken).ConfigureAwait(false);
         }
+
+        throw await ImmichApiException.FromResponseAsync(response, "POST", url, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<T?> PutAsync<T>(string url, object request, CancellationToken cancellationToken)
     {
-        try
-        {
-            var response = await _httpClient.PutAsJsonAsync(url, request, JsonOptions, cancellationToken).ConfigureAwait(false);
+        var response = await _httpClient.PutAsJsonAsync(url, request, JsonOptions, cancellationToken).ConfigureAwait(false);
 
-            if (response.IsSuccessStatusCode)
-            {
-                return await response.Content.ReadFromJsonAsync<T>(JsonOptions, cancellationToken).ConfigureAwait(false);
-            }
-
-            await LogErrorResponse(response, "PUT", url).ConfigureAwait(false);
-            return default;
-        }
-        catch (Exception ex)
+        if (response.IsSuccessStatusCode)
         {
-            _logger.LogError(ex, "PUT request failed: {Url}", url);
-            return default;
+            return await response.Content.ReadFromJsonAsync<T>(JsonOptions, cancellationToken).ConfigureAwait(false);
         }
+
+        throw await ImmichApiException.FromResponseAsync(response, "PUT", url, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<T?> PatchAsync<T>(string url, object request, CancellationToken cancellationToken)
     {
-        try
-        {
-            var content = JsonContent.Create(request, options: JsonOptions);
-            var response = await _httpClient.PatchAsync(url, content, cancellationToken).ConfigureAwait(false);
+        var content = JsonContent.Create(request, options: JsonOptions);
+        var response = await _httpClient.PatchAsync(url, content, cancellationToken).ConfigureAwait(false);
 
-            if (response.IsSuccessStatusCode)
-            {
-                return await response.Content.ReadFromJsonAsync<T>(JsonOptions, cancellationToken).ConfigureAwait(false);
-            }
-
-            await LogErrorResponse(response, "PATCH", url).ConfigureAwait(false);
-            return default;
-        }
-        catch (Exception ex)
+        if (response.IsSuccessStatusCode)
         {
-            _logger.LogError(ex, "PATCH request failed: {Url}", url);
-            return default;
+            return await response.Content.ReadFromJsonAsync<T>(JsonOptions, cancellationToken).ConfigureAwait(false);
         }
+
+        throw await ImmichApiException.FromResponseAsync(response, "PATCH", url, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<bool> DeleteAsync(string url, CancellationToken cancellationToken)
     {
-        try
+        var response = await _httpClient.DeleteAsync(url, cancellationToken).ConfigureAwait(false);
+
+        if (response.IsSuccessStatusCode || response.StatusCode == HttpStatusCode.NoContent)
         {
-            var response = await _httpClient.DeleteAsync(url, cancellationToken).ConfigureAwait(false);
-
-            if (response.IsSuccessStatusCode || response.StatusCode == HttpStatusCode.NoContent)
-            {
-                return true;
-            }
-
-            await LogErrorResponse(response, "DELETE", url).ConfigureAwait(false);
-            return false;
+            return true;
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "DELETE request failed: {Url}", url);
-            return false;
-        }
-    }
 
-    private async Task LogErrorResponse(HttpResponseMessage response, string method, string url)
-    {
-        var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-        _logger.LogError("{Method} {Url} failed with {StatusCode}: {Body}",
-            method, url, (int)response.StatusCode, body);
+        throw await ImmichApiException.FromResponseAsync(response, "DELETE", url, cancellationToken).ConfigureAwait(false);
     }
 
     private static string GetContentType(string fileName) => Path.GetExtension(fileName).ToLowerInvariant() switch

--- a/ImmichMCP/ImmichMCP.csproj
+++ b/ImmichMCP/ImmichMCP.csproj
@@ -33,4 +33,8 @@
     <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="ImmichMCP.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/ImmichMCP/Tools/AssetTools.cs
+++ b/ImmichMCP/Tools/AssetTools.cs
@@ -4,6 +4,8 @@ using ModelContextProtocol.Server;
 using ImmichMCP.Client;
 using ImmichMCP.Models.Common;
 using ImmichMCP.Models.Assets;
+using ImmichMCP.Models.Albums;
+using ImmichMCP.Models.SharedLinks;
 using static ImmichMCP.Utils.ParsingHelpers;
 
 namespace ImmichMCP.Tools;
@@ -14,6 +16,103 @@ namespace ImmichMCP.Tools;
 [McpServerToolType]
 public static class AssetTools
 {
+    [McpServerTool(Name = "immich_assets_upload_authorize")]
+    [Description(
+        "Authorize a client-side bulk upload WITHOUT exposing the API key. Creates (or reuses) an album " +
+        "and returns a short-lived, upload-only shared-link URL. The client then POSTs files DIRECTLY to " +
+        "upload_url (multipart/form-data, field 'assetData', plus fileCreatedAt and fileModifiedAt as ISO-8601 " +
+        "datetimes WITH a 'Z' suffix) — no API key, no local install beyond curl. Every uploaded asset lands in " +
+        "the album. Re-running is safe and resumable: Immich deduplicates by file checksum, so already-uploaded " +
+        "files return status 'duplicate' and are not re-added.")]
+    public static async Task<string> AuthorizeUpload(
+        ImmichClient client,
+        [Description("Name of a NEW album to create for these uploads. Provide this OR album_id, not both.")] string? albumName = null,
+        [Description("Existing album ID (UUID) to upload into. Provide this OR album_name, not both.")] string? albumId = null,
+        [Description("Minutes until the upload URL expires (default 60, clamped to 1..1440).")] int ttlMinutes = 60)
+    {
+        var hasName = !string.IsNullOrWhiteSpace(albumName);
+        var hasId = !string.IsNullOrWhiteSpace(albumId);
+        if (hasName == hasId)
+        {
+            return JsonSerializer.Serialize(McpErrorResponse.Create(
+                ErrorCodes.Validation,
+                "Provide exactly one of album_name (to create a new album) or album_id (to use an existing one).",
+                meta: new McpMeta { ImmichBaseUrl = client.BaseUrl }));
+        }
+
+        string resolvedAlbumId;
+        string resolvedAlbumName;
+        if (hasName)
+        {
+            var album = await client.CreateAlbumAsync(new AlbumCreateRequest { AlbumName = albumName! }).ConfigureAwait(false);
+            if (album == null)
+            {
+                return JsonSerializer.Serialize(McpErrorResponse.Create(
+                    ErrorCodes.UpstreamError,
+                    "Failed to create album for upload.",
+                    meta: new McpMeta { ImmichBaseUrl = client.BaseUrl }));
+            }
+            resolvedAlbumId = album.Id;
+            resolvedAlbumName = album.AlbumName;
+        }
+        else
+        {
+            var album = await client.GetAlbumAsync(albumId!).ConfigureAwait(false);
+            if (album == null)
+            {
+                return JsonSerializer.Serialize(McpErrorResponse.Create(
+                    ErrorCodes.NotFound,
+                    $"Album with ID {albumId} not found.",
+                    meta: new McpMeta { ImmichBaseUrl = client.BaseUrl }));
+            }
+            resolvedAlbumId = album.Id;
+            resolvedAlbumName = album.AlbumName;
+        }
+
+        var ttl = Math.Clamp(ttlMinutes, 1, 1440);
+        var expiresAt = DateTime.UtcNow.AddMinutes(ttl);
+
+        var link = await client.CreateSharedLinkAsync(new SharedLinkCreateRequest
+        {
+            Type = "ALBUM",
+            AlbumId = resolvedAlbumId,
+            AllowUpload = true,
+            AllowDownload = false,
+            ExpiresAt = expiresAt
+        }).ConfigureAwait(false);
+
+        if (link == null || string.IsNullOrEmpty(link.Key))
+        {
+            return JsonSerializer.Serialize(McpErrorResponse.Create(
+                ErrorCodes.UpstreamError,
+                "Failed to create upload authorization link.",
+                meta: new McpMeta { ImmichBaseUrl = client.BaseUrl }));
+        }
+
+        var baseUrl = client.BaseUrl.TrimEnd('/');
+        var uploadUrl = $"{baseUrl}/api/assets?key={link.Key}";
+
+        var response = McpResponse<object>.Success(
+            new
+            {
+                upload_url = uploadUrl,
+                album_id = resolvedAlbumId,
+                album_name = resolvedAlbumName,
+                shared_link_id = link.Id,
+                expires_at = expiresAt.ToString("O"),
+                required_fields = new[] { "assetData", "fileCreatedAt", "fileModifiedAt" },
+                notes = "POST each file to upload_url with multipart/form-data. No API key needed. " +
+                        "Timestamps must be ISO-8601 with a 'Z'. Re-running skips existing files (status 'duplicate').",
+                curl_example =
+                    "TS=$(date -u +%Y-%m-%dT%H:%M:%S.000Z); " +
+                    $"for f in /path/to/dir/*; do curl --retry 3 -sf -X POST \"{uploadUrl}\" " +
+                    "-F \"assetData=@$f\" -F \"deviceId=mcp-client\" -F \"deviceAssetId=$f\" " +
+                    "-F \"fileCreatedAt=$TS\" -F \"fileModifiedAt=$TS\"; done"
+            },
+            new McpMeta { ImmichBaseUrl = client.BaseUrl });
+        return JsonSerializer.Serialize(response);
+    }
+
     [McpServerTool(Name = "immich_assets_list")]
     [Description("List recent assets with optional filters and pagination.")]
     public static async Task<string> List(

--- a/ImmichMCP/Tools/Gateway/ImmichToolGateway.cs
+++ b/ImmichMCP/Tools/Gateway/ImmichToolGateway.cs
@@ -1,9 +1,12 @@
+using System.Net;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
+using ImmichMCP.Client;
+using ImmichMCP.Models.Common;
 
 namespace ImmichMCP.Tools.Gateway;
 
@@ -139,13 +142,92 @@ public sealed class ImmichToolGateway
 
         try
         {
-            return await definition.Tool.InvokeAsync(request, cancellationToken).ConfigureAwait(false);
+            var result = await definition.Tool.InvokeAsync(request, cancellationToken).ConfigureAwait(false);
+            // Tools serialize their own {"ok":false,...} error envelopes as text; per the MCP
+            // spec a tool execution error must also flag the result with isError: true.
+            return MarkErrorEnvelope(result);
+        }
+        catch (ImmichApiException ex)
+        {
+            _logger.LogError(ex, "Immich tool {ToolName} failed upstream ({StatusCode})", toolName, (int)ex.StatusCode);
+            return JsonResult(BuildUpstreamError(ex), isError: true);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Dynamic Immich tool invocation failed for {ToolName}", toolName);
             return TextResult(ex.Message, isError: true);
         }
+    }
+
+    /// <summary>
+    /// Flags a result as an error when the tool serialized an {"ok": false} envelope,
+    /// so the transport-level isError matches the application-level outcome.
+    /// </summary>
+    internal static CallToolResult MarkErrorEnvelope(CallToolResult result)
+    {
+        if (result.IsError == true)
+        {
+            return result;
+        }
+
+        foreach (var block in result.Content)
+        {
+            if (block is TextContentBlock text && IsErrorEnvelope(text.Text))
+            {
+                return new CallToolResult { Content = result.Content, IsError = true };
+            }
+        }
+
+        return result;
+    }
+
+    internal static bool IsErrorEnvelope(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text) || text[0] != '{')
+        {
+            return false;
+        }
+
+        try
+        {
+            return JsonNode.Parse(text) is JsonObject obj
+                && obj.TryGetPropertyValue("ok", out var ok)
+                && ok is JsonValue value
+                && value.TryGetValue<bool>(out var isOk)
+                && !isOk;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    internal static object BuildUpstreamError(ImmichApiException ex)
+    {
+        var code = ex.StatusCode switch
+        {
+            HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden => ErrorCodes.AuthFailed,
+            HttpStatusCode.NotFound => ErrorCodes.NotFound,
+            HttpStatusCode.BadRequest or HttpStatusCode.UnprocessableEntity => ErrorCodes.Validation,
+            HttpStatusCode.TooManyRequests => ErrorCodes.RateLimit,
+            _ => ErrorCodes.UpstreamError
+        };
+
+        return new
+        {
+            ok = false,
+            error = new
+            {
+                code,
+                message = ex.Message,
+                details = new
+                {
+                    status = (int)ex.StatusCode,
+                    path = ex.Path,
+                    body = ex.ResponseBody
+                }
+            }
+        };
     }
 
     public IReadOnlyCollection<Tool> GetVisibleTools(object? session)

--- a/ImmichMCP/Utils/UtcIsoDateTimeConverter.cs
+++ b/ImmichMCP/Utils/UtcIsoDateTimeConverter.cs
@@ -1,0 +1,31 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ImmichMCP.Utils;
+
+/// <summary>
+/// Serializes <see cref="DateTime"/> values as UTC ISO 8601 with a trailing 'Z'.
+///
+/// Immich v3 validates datetime request fields with Zod (z.iso.datetime), which rejects
+/// any datetime string lacking a timezone designator (Z or +/-hh:mm) with HTTP 400.
+/// System.Text.Json's default serializer emits DateTimes whose Kind is Unspecified
+/// (e.g. those produced by DateTime.Parse("2026-06-02")) without a suffix, so date
+/// filters like takenAfter/takenBefore/updatedAfter were silently rejected upstream.
+/// </summary>
+public sealed class UtcIsoDateTimeConverter : JsonConverter<DateTime>
+{
+    public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        => reader.GetDateTime();
+
+    public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+    {
+        var utc = value.Kind switch
+        {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+        };
+        writer.WriteStringValue(utc.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture));
+    }
+}

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Or with Docker:
 | `immich_assets_download_thumbnail` | Get thumbnail/preview URLs |
 | `immich_assets_upload` | Upload asset (base64) |
 | `immich_assets_upload_from_path` | Upload from local file path |
+| `immich_assets_upload_authorize` | Mint a short-lived, upload-only URL so a client can upload local files **directly** to Immich (no API key exposed) |
 | `immich_assets_update` | Update asset metadata |
 | `immich_assets_bulk_update` | Bulk update multiple assets |
 | `immich_assets_delete` | Delete asset(s) |
@@ -283,6 +284,28 @@ Find photos of sunset at the beach
 
 ```
 Archive all photos from 2020 that aren't favorites
+```
+
+### Upload a local folder (no install, no exposed API key)
+
+```
+Upload ~/Photos/Iceland2026 to Immich into an album called "Iceland 2026"
+```
+
+Because the MCP server is remote and cannot read your disk, `immich_assets_upload_authorize`
+mints a short-lived, **upload-only** shared-link URL scoped to a (dynamically created) album.
+The client then uploads the files **directly to Immich** with `curl` it already has — the master
+API key never leaves the server, and no CLI/script needs to be installed. Re-running is safe and
+resumable: Immich deduplicates by content, so already-uploaded files return `duplicate`. See the
+[uploading-local-media](docs/uploading-local-media.md) doc for the exact client recipe.
+
+```jsonc
+// immich_assets_upload_authorize(album_name: "Iceland 2026", ttl_minutes: 120)
+{
+  "upload_url": "https://immich.example/api/assets?key=<token>",
+  "album_id": "…", "shared_link_id": "…", "expires_at": "2026-07-02T14:00:00.0000000Z"
+}
+// then: POST each file to upload_url (multipart: assetData, fileCreatedAt, fileModifiedAt)
 ```
 
 ## Safety Features

--- a/docs/uploading-local-media.md
+++ b/docs/uploading-local-media.md
@@ -1,0 +1,58 @@
+# Uploading local media to Immich
+
+The ImmichMCP server is typically **remote** and cannot read the client's disk. So it never
+handles file bytes. Instead, `immich_assets_upload_authorize` mints a short-lived, **upload-only**
+credential and the client uploads **directly to Immich** with `curl` it already has. The master
+API key never leaves the server, and nothing needs to be installed.
+
+This is the same separation Immich's own CLI uses; here it's exposed as a single MCP tool so any
+agent (Claude Code, Codex, …) can drive it.
+
+## Flow
+
+1. **Authorize** — one MCP call:
+
+   ```
+   immich_assets_upload_authorize(album_name: "Iceland 2026", ttl_minutes: 120)
+   ```
+
+   Returns `upload_url` (contains `?key=<token>`), `album_id`, `shared_link_id`, `expires_at`.
+   Pass `album_id` instead of `album_name` to upload into an existing album.
+
+2. **Upload** each file to `upload_url` — no API key, required multipart fields `assetData`,
+   `fileCreatedAt`, `fileModifiedAt` (ISO-8601 **with a `Z`**):
+
+   ```bash
+   URL='<upload_url>'
+   TS=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+   find "<path>" -type f \( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' \
+        -o -iname '*.heic' -o -iname '*.heif' -o -iname '*.mp4' -o -iname '*.mov' \
+        -o -iname '*.gif' -o -iname '*.webp' -o -iname '*.dng' \) -print0 \
+   | xargs -0 -P 8 -I{} curl --retry 3 -sf -o /dev/null -w '%{http_code} {}\n' \
+       -X POST "$URL" \
+       -F 'assetData=@{}' -F 'deviceId=mcp-client' -F 'deviceAssetId={}' \
+       -F "fileCreatedAt=$TS" -F "fileModifiedAt=$TS"
+   ```
+
+   `-P 8` runs 8 concurrent uploads. `201`=created, `200`=duplicate, anything else=failed.
+
+3. **Revoke** when done (optional): `immich_shared_links_delete(id: <shared_link_id>)`.
+
+## Resumability
+
+Immich deduplicates by file **content**, so re-running the same command is safe — already-uploaded
+files return `duplicate` and are not re-added. An interrupted run just needs to be re-run; it
+converges.
+
+Caveat: the share token cannot call `bulk-upload-check`, so a resume re-sends bytes for
+already-uploaded files (rejected as duplicates server-side). Correct, but not bandwidth-optimal.
+For a very large re-run, keep a local list of files that returned `201`/`200` and skip them.
+
+## Expiry
+
+If a long import outlives `ttl_minutes`, uploads start returning `401`. Call
+`immich_assets_upload_authorize` again for the **same album** (`album_id`) to get a fresh
+`upload_url` and continue.
+
+> Never send file bytes through MCP tool calls (base64) — it destroys the context window. Bytes go
+> client→Immich directly. That is the entire purpose of the authorize tool.


### PR DESCRIPTION
## Summary

Three connected improvements to the Immich MCP server, each verified against a live Immich v3 instance.

### 1. Fix: v3 datetime serialization (the visible bug)
Immich v3 validates datetimes with Zod, which **rejects timezone-less strings**. System.Text.Json emitted `Kind=Unspecified` DateTimes with no suffix, so `immich_search_metadata` date filters (`takenAfter`/`takenBefore`) were rejected with **HTTP 400** — and the client swallowed that into an empty result, surfacing as a false "0 matches".
- New `UtcIsoDateTimeConverter` so every outbound `DateTime` carries a `Z`.

### 2. Fix: never swallow upstream errors (MCP-spec compliance)
The client turned non-2xx responses (and exceptions) into empty/`null`/`false` — masking failures as success. Per the MCP spec, tool-execution errors must be returned as a result with **`isError: true`**, not fake success.
- Client now throws `ImmichApiException` on failure (keeping only the legitimate `404`-by-id → `null`).
- Gateway boundary renders failures as spec-compliant `isError: true` results with a mapped error code, and flags any `{"ok":false}` envelope as `isError`.

### 3. Feature: authorized token-based direct upload
`immich_assets_upload_authorize` creates (or reuses) an album and mints a short-lived, **upload-only** shared-link URL. The client uploads local files **directly to Immich** with the token — the master API key never leaves the server, and nothing needs to be installed beyond `curl`. Uploads land in the album and are resumable via Immich's content dedup.
- Reuses existing `CreateAlbumAsync` + `CreateSharedLinkAsync`.
- Client recipe documented in `docs/uploading-local-media.md`.

## Testing
- Unit: **60 passed, 0 failed** (new tests for date serialization, error surfacing, gateway `isError` mapping, tool-count guard 48→49).
- Live integration against a real Immich v3 server: date-filter search returns results; **authorize → token-only upload → lands in album → torn down** — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)