### PR TITLE
fix: model asset duration as string (Immich returns a timespan string, not int)

### DIFF
--- a/ImmichMCP/Models/Assets/Asset.cs
+++ b/ImmichMCP/Models/Assets/Asset.cs
@@ -62,7 +62,7 @@ public record Asset
     public bool HasMetadata { get; init; }
 
     [JsonPropertyName("duration")]
-    public int? Duration { get; init; }
+    public string? Duration { get; init; }
 
     [JsonPropertyName("visibility")]
     public string Visibility { get; init; } = "timeline";
@@ -329,7 +329,7 @@ public record AssetSummary
     public bool IsArchived { get; init; }
 
     [JsonPropertyName("duration")]
-    public int? Duration { get; init; }
+    public string? Duration { get; init; }
 
     [JsonPropertyName("visibility")]
     public string Visibility { get; init; } = "timeline";


### PR DESCRIPTION
## Root cause

Immich returns the asset `duration` field as a **timespan string** (e.g. `"0:00:00.00000"` — images use `"0:00:00.00000"`, videos a real duration), not an integer. The asset models in `ImmichMCP/Models/Assets/Asset.cs` typed it as `int?`, so `System.Text.Json` throws when deserializing any response that contains asset objects.

### Exact exception (server v3.1.3 against Immich v2.7.5)

```
System.Text.Json.JsonException: The JSON value could not be converted to System.Nullable`1[System.Int32]. Path: $.assets.items[0].duration | LineNumber: 0 | BytePositionInLine: 922.
 ---> System.InvalidOperationException: Cannot get the value of a token type 'String' as a number.
   at System.Text.Json.Utf8JsonReader.GetInt32()
   at ImmichMCP.Client.ImmichClient.SearchMetadataAsync(MetadataSearchRequest request, CancellationToken cancellationToken) in /src/ImmichMCP/Client/ImmichClient.cs:line 333
```

## Impact

Every tool that returns asset objects fails; tools whose payloads contain no assets work fine.

- **FAIL:** `immich_assets_list`, `immich_search_smart`, `immich_search_metadata`
- **OK:** `immich_ping`, `immich_assets_statistics`, `immich_albums_list`, `immich_albums_statistics`, `immich_people_list`, `immich_tags_list`

## Steps to reproduce

1. Run the MCP server (`IMMICH_TOOL_MODE=static`) with a read-only API key against an Immich v2.x server.
2. Call any asset-returning tool, e.g. `immich_search_smart` (or `immich_assets_list` / `immich_search_metadata`).
3. The server throws the `JsonException` above. Reproducible with a raw HTTP call to the container — no MCP client involved.

## Fix

Change the `duration` property type from `int?` to `string?` on both asset models in `ImmichMCP/Models/Assets/Asset.cs` (the `Asset` response model and the `AssetSummary` projection). `duration` is a pure pass-through DTO field — the only usage is `Duration = asset.Duration` in `AssetSummary.FromAsset`; no code does arithmetic or numeric comparison on it, so the type change is safe. The unrelated `int? duration` upload **parameter** in `ImmichClient.UploadAssetAsync` is left untouched.

## Verification

Compile-unverified: this is a one-line-per-model type change made in an environment without the .NET SDK. The change is a straightforward `int?` → `string?` swap; the only consumer (`Duration = asset.Duration`) and the `Duration = null` test fixture both remain valid for `string?`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
