### PR TITLE
fix(client): align Immich API contracts

### DIFF
--- a/ImmichMCP.Tests/Client/ImmichClientAlbumTests.cs
+++ b/ImmichMCP.Tests/Client/ImmichClientAlbumTests.cs
@@ -66,6 +66,35 @@ public class ImmichClientAlbumTests
     }
 
     [Fact]
+    public async Task GetAlbumAsync_MapsContributorAssetCount_FromImmichContract()
+    {
+        // Arrange
+        const string responseJson = """
+            {
+              "id": "album-1",
+              "contributorCounts": [
+                {
+                  "userId": "user-1",
+                  "assetCount": 7
+                }
+              ]
+            }
+            """;
+
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        handler.When(HttpMethod.Get, "*/albums/album-1")
+            .Respond("application/json", responseJson);
+
+        // Act
+        var result = await client.GetAlbumAsync("album-1");
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.ContributorCounts.Should().ContainSingle();
+        result.ContributorCounts![0].AssetCount.Should().Be(7);
+    }
+
+    [Fact]
     public async Task GetAlbumAsync_ReturnsNull_WhenNotFound()
     {
         // Arrange

--- a/ImmichMCP.Tests/Client/ImmichClientAssetTests.cs
+++ b/ImmichMCP.Tests/Client/ImmichClientAssetTests.cs
@@ -42,6 +42,70 @@ public class ImmichClientAssetTests
     }
 
     [Fact]
+    public async Task GetAssetsAsync_DeserializesDuration_WhenLegacyImmichReturnsTimespanString()
+    {
+        // Arrange
+        const string responseJson = """
+            {
+              "assets": {
+                "total": 1,
+                "count": 1,
+                "items": [
+                  {
+                    "id": "asset-1",
+                    "duration": "0:00:01.23400"
+                  }
+                ],
+                "nextPage": null
+              }
+            }
+            """;
+
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        handler.When(HttpMethod.Post, "*/search/metadata")
+            .Respond("application/json", responseJson);
+
+        // Act
+        var result = await client.GetAssetsAsync();
+
+        // Assert
+        result.Should().ContainSingle();
+        result[0].Duration.Should().Be(1234);
+    }
+
+    [Fact]
+    public async Task GetAssetsAsync_DeserializesDuration_WhenImmichV3ReturnsMilliseconds()
+    {
+        // Arrange
+        const string responseJson = """
+            {
+              "assets": {
+                "total": 1,
+                "count": 1,
+                "items": [
+                  {
+                    "id": "asset-1",
+                    "duration": 1234
+                  }
+                ],
+                "nextPage": null
+              }
+            }
+            """;
+
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        handler.When(HttpMethod.Post, "*/search/metadata")
+            .Respond("application/json", responseJson);
+
+        // Act
+        var result = await client.GetAssetsAsync();
+
+        // Assert
+        result.Should().ContainSingle();
+        result[0].Duration.Should().Be(1234);
+    }
+
+    [Fact]
     public async Task GetAssetsAsync_ReturnsEmptyList_WhenNoAssets()
     {
         // Arrange
@@ -159,6 +223,47 @@ public class ImmichClientAssetTests
 
         // Assert
         result.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task UploadAssetAsync_FetchesFullAsset_AfterMediaResponse()
+    {
+        // Arrange
+        const string uploadResponseJson = """
+            {
+              "id": "asset-1",
+              "status": "created"
+            }
+            """;
+        const string assetResponseJson = """
+            {
+              "id": "asset-1",
+              "type": "IMAGE",
+              "originalFileName": "photo.jpg",
+              "visibility": "archive",
+              "duration": 1234
+            }
+            """;
+
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        handler.When(HttpMethod.Post, "*/assets")
+            .Respond("application/json", uploadResponseJson);
+        handler.When(HttpMethod.Get, "*/assets/asset-1")
+            .Respond("application/json", assetResponseJson);
+
+        // Act
+        var result = await client.UploadAssetAsync(
+            [1, 2, 3],
+            "photo.jpg",
+            DateTime.UtcNow,
+            isArchived: true);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Id.Should().Be("asset-1");
+        result.OriginalFileName.Should().Be("photo.jpg");
+        result.Type.Should().Be("IMAGE");
+        result.Visibility.Should().Be("archive");
     }
 
     [Fact]

--- a/ImmichMCP.Tests/Client/ImmichClientPeopleTests.cs
+++ b/ImmichMCP.Tests/Client/ImmichClientPeopleTests.cs
@@ -8,6 +8,46 @@ namespace ImmichMCP.Tests.Client;
 public class ImmichClientPeopleTests
 {
     [Fact]
+    public async Task GetPersonAssetsAsync_UsesMetadataSearchWithPersonFilter()
+    {
+        // Arrange
+        const string responseJson = """
+            {
+              "assets": {
+                "total": 1,
+                "count": 1,
+                "items": [
+                  {
+                    "id": "asset-1",
+                    "duration": 1234
+                  }
+                ],
+                "nextPage": null
+              }
+            }
+            """;
+
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        string? requestBody = null;
+        handler.When(HttpMethod.Post, "*/search/metadata")
+            .With(request =>
+            {
+                requestBody = request.Content!.ReadAsStringAsync().Result;
+                return true;
+            })
+            .Respond("application/json", responseJson);
+
+        // Act
+        var result = await client.GetPersonAssetsAsync("person-1");
+
+        // Assert
+        result.Should().ContainSingle();
+        result[0].Id.Should().Be("asset-1");
+        requestBody.Should().Contain("\"personIds\":[\"person-1\"]");
+        requestBody.Should().Contain("\"withExif\":true");
+    }
+
+    [Fact]
     public async Task GetPeopleAsync_ReturnsPeople_WhenSuccessful()
     {
         // Arrange

--- a/ImmichMCP.Tests/Client/ImmichClientSharedLinkTests.cs
+++ b/ImmichMCP.Tests/Client/ImmichClientSharedLinkTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text.Json;
 using FluentAssertions;
 using RichardSzalay.MockHttp;
 using ImmichMCP.Models.SharedLinks;
@@ -95,5 +96,31 @@ public class ImmichClientSharedLinkTests
 
         // Assert
         result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AddAssetsToSharedLinkAsync_MapsAssetIdResponse()
+    {
+        // Arrange
+        const string responseJson = """
+            [
+              {
+                "assetId": "asset-1",
+                "success": true
+              }
+            ]
+            """;
+
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        handler.When(HttpMethod.Put, "*/shared-links/link-1/assets")
+            .Respond("application/json", responseJson);
+
+        // Act
+        var result = await client.AddAssetsToSharedLinkAsync("link-1", ["asset-1"]);
+
+        // Assert
+        using var json = JsonDocument.Parse(JsonSerializer.Serialize(result));
+        json.RootElement[0].GetProperty("assetId").GetString().Should().Be("asset-1");
+        json.RootElement[0].GetProperty("success").GetBoolean().Should().BeTrue();
     }
 }

--- a/ImmichMCP.Tests/Gateway/ImmichToolGatewayTests.cs
+++ b/ImmichMCP.Tests/Gateway/ImmichToolGatewayTests.cs
@@ -31,6 +31,19 @@ public class ImmichToolGatewayTests
     }
 
     [Fact]
+    public void TagUpdateSchema_ExposesOnlyFieldsSupportedByImmich()
+    {
+        using var services = CreateServices();
+        var registry = services.GetRequiredService<ImmichToolRegistry>();
+
+        registry.TryGetTool("immich_tags_update", out var definition).Should().BeTrue();
+        var properties = definition.Tool.ProtocolTool.InputSchema.GetProperty("properties");
+
+        properties.TryGetProperty("color", out _).Should().BeTrue();
+        properties.TryGetProperty("name", out _).Should().BeFalse();
+    }
+
+    [Fact]
     public void GatewayStartsWithOnlyBootstrapTools()
     {
         using var services = CreateServices();

--- a/ImmichMCP.Tests/Tools/ActivityToolsTests.cs
+++ b/ImmichMCP.Tests/Tools/ActivityToolsTests.cs
@@ -1,0 +1,35 @@
+using System.Text.Json;
+using FluentAssertions;
+using RichardSzalay.MockHttp;
+using ImmichMCP.Tests.Fixtures;
+using ImmichMCP.Tools;
+
+namespace ImmichMCP.Tests.Tools;
+
+public class ActivityToolsTests
+{
+    [Fact]
+    public async Task Statistics_ReturnsCommentAndLikeCounts()
+    {
+        // Arrange: raw Immich v3 ActivityStatisticsResponseDto shape.
+        const string responseJson = """
+            {
+              "comments": 3,
+              "likes": 4
+            }
+            """;
+
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        handler.When(HttpMethod.Get, "*/activities/statistics*")
+            .Respond("application/json", responseJson);
+
+        // Act
+        var response = await ActivityTools.Statistics(client, "album-1");
+
+        // Assert
+        using var json = JsonDocument.Parse(response);
+        var result = json.RootElement.GetProperty("result");
+        result.GetProperty("comments").GetInt32().Should().Be(3);
+        result.GetProperty("likes").GetInt32().Should().Be(4);
+    }
+}

--- a/ImmichMCP.Tests/Tools/HealthToolsTests.cs
+++ b/ImmichMCP.Tests/Tools/HealthToolsTests.cs
@@ -1,0 +1,74 @@
+using System.Text.Json;
+using FluentAssertions;
+using RichardSzalay.MockHttp;
+using ImmichMCP.Tests.Fixtures;
+using ImmichMCP.Tools;
+
+namespace ImmichMCP.Tests.Tools;
+
+public class HealthToolsTests
+{
+    [Fact]
+    public async Task GetCapabilities_UsesCurrentImmichFeatureContractAndEndpoints()
+    {
+        // Arrange: raw Immich v3 ServerAboutResponseDto and ServerFeaturesDto shapes.
+        const string aboutJson = """
+            {
+              "version": "3.0.2",
+              "versionUrl": "https://github.com/immich-app/immich/releases/tag/v3.0.2",
+              "licensed": false
+            }
+            """;
+        const string featuresJson = """
+            {
+              "configFile": true,
+              "duplicateDetection": true,
+              "email": true,
+              "facialRecognition": true,
+              "importFaces": true,
+              "map": true,
+              "oauth": true,
+              "oauthAutoLaunch": true,
+              "ocr": true,
+              "passwordLogin": true,
+              "realtimeTranscoding": true,
+              "reverseGeocoding": true,
+              "search": true,
+              "sidecar": true,
+              "smartSearch": true,
+              "trash": true
+            }
+            """;
+
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        handler.When(HttpMethod.Get, "*/server/about")
+            .Respond("application/json", aboutJson);
+        handler.When(HttpMethod.Get, "*/server/features")
+            .Respond("application/json", featuresJson);
+
+        // Act
+        var response = await HealthTools.GetCapabilities(client);
+
+        // Assert
+        using var json = JsonDocument.Parse(response);
+        var result = json.RootElement.GetProperty("result");
+        var features = result.GetProperty("features");
+        features.GetProperty("ImportFaces").GetBoolean().Should().BeTrue();
+        features.GetProperty("Ocr").GetBoolean().Should().BeTrue();
+        features.GetProperty("RealtimeTranscoding").GetBoolean().Should().BeTrue();
+        features.GetProperty("OauthAutoLaunch").GetBoolean().Should().BeTrue();
+        features.TryGetProperty("Import", out _).Should().BeFalse();
+
+        result.GetProperty("endpoints")
+            .GetProperty("assets")
+            .GetProperty("list")
+            .GetString()
+            .Should().Be("/api/search/metadata");
+
+        result.GetProperty("endpoints")
+            .GetProperty("people")
+            .GetProperty("assets")
+            .GetString()
+            .Should().Be("/api/search/metadata");
+    }
+}

--- a/ImmichMCP.Tests/Tools/PeopleToolsTests.cs
+++ b/ImmichMCP.Tests/Tools/PeopleToolsTests.cs
@@ -1,0 +1,105 @@
+using System.Text.Json;
+using FluentAssertions;
+using RichardSzalay.MockHttp;
+using ImmichMCP.Tests.Fixtures;
+using ImmichMCP.Tools;
+
+namespace ImmichMCP.Tests.Tools;
+
+public class PeopleToolsTests
+{
+    [Fact]
+    public async Task List_UsesServerPaginationAndComputesVisibleCount()
+    {
+        // Arrange: raw Immich v3 PeopleResponseDto shape.
+        const string responseJson = """
+            {
+              "people": [
+                {
+                  "id": "person-26",
+                  "name": "Page Two Person",
+                  "birthDate": null,
+                  "thumbnailPath": "/people/person-26/thumbnail",
+                  "isHidden": false
+                }
+              ],
+              "total": 700,
+              "hidden": 5,
+              "hasNextPage": true
+            }
+            """;
+
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        string? requestUri = null;
+        handler.When(HttpMethod.Get, "*/people*")
+            .With(request =>
+            {
+                requestUri = request.RequestUri!.ToString();
+                return true;
+            })
+            .Respond("application/json", responseJson);
+
+        // Act
+        var response = await PeopleTools.List(client, withHidden: true, page: 2, size: 25);
+
+        // Assert
+        requestUri.Should().Contain("withHidden=true");
+        requestUri.Should().Contain("page=2");
+        requestUri.Should().Contain("size=25");
+
+        using var json = JsonDocument.Parse(response);
+        var result = json.RootElement.GetProperty("result");
+        result.GetProperty("people").GetArrayLength().Should().Be(1);
+        result.GetProperty("visible").GetInt32().Should().Be(695);
+        result.GetProperty("hidden").GetInt32().Should().Be(5);
+
+        var meta = json.RootElement.GetProperty("meta");
+        meta.GetProperty("total").GetInt32().Should().Be(700);
+        meta.GetProperty("next").GetString().Should().Be("page=3&size=25");
+    }
+
+    [Fact]
+    public async Task Assets_UsesPaginatedMetadataSearchWithPersonFilter()
+    {
+        // Arrange: raw Immich v3 SearchResponseDto shape.
+        const string responseJson = """
+            {
+              "assets": {
+                "total": 42,
+                "count": 1,
+                "items": [
+                  {
+                    "id": "asset-26",
+                    "duration": 1234
+                  }
+                ],
+                "nextPage": "3"
+              }
+            }
+            """;
+
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        string? requestBody = null;
+        handler.When(HttpMethod.Post, "*/search/metadata")
+            .With(request =>
+            {
+                requestBody = request.Content!.ReadAsStringAsync().Result;
+                return true;
+            })
+            .Respond("application/json", responseJson);
+
+        // Act
+        var response = await PeopleTools.Assets(client, "person-1", page: 2, size: 25);
+
+        // Assert
+        requestBody.Should().Contain("\"personIds\":[\"person-1\"]");
+        requestBody.Should().Contain("\"page\":2");
+        requestBody.Should().Contain("\"size\":25");
+
+        using var json = JsonDocument.Parse(response);
+        json.RootElement.GetProperty("result").GetArrayLength().Should().Be(1);
+        var meta = json.RootElement.GetProperty("meta");
+        meta.GetProperty("total").GetInt32().Should().Be(42);
+        meta.GetProperty("next").GetString().Should().Be("3");
+    }
+}

--- a/ImmichMCP/Client/ImmichClient.cs
+++ b/ImmichMCP/Client/ImmichClient.cs
@@ -220,7 +220,17 @@ public class ImmichClient
             var response = await _httpClient.PostAsync("api/assets", formContent, cancellationToken).ConfigureAwait(false);
             if (response.IsSuccessStatusCode)
             {
-                return await response.Content.ReadFromJsonAsync<Asset>(JsonOptions, cancellationToken).ConfigureAwait(false);
+                var uploadResult = await response.Content
+                    .ReadFromJsonAsync<AssetMediaResponse>(JsonOptions, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (string.IsNullOrWhiteSpace(uploadResult?.Id))
+                {
+                    _logger.LogError("Immich returned a successful upload response without an asset ID");
+                    return null;
+                }
+
+                return await GetAssetAsync(uploadResult.Id, cancellationToken).ConfigureAwait(false);
             }
 
             var error = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
@@ -464,10 +474,29 @@ public class ImmichClient
     /// <summary>
     /// Gets all people.
     /// </summary>
-    public async Task<PeopleResponse?> GetPeopleAsync(bool? withHidden = null, CancellationToken cancellationToken = default)
+    public Task<PeopleResponse?> GetPeopleAsync(
+        bool? withHidden = null,
+        CancellationToken cancellationToken = default)
     {
-        var url = withHidden.HasValue
-            ? $"api/people?withHidden={withHidden.Value.ToString().ToLower()}"
+        return GetPeopleAsync(withHidden, page: null, size: null, cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets a page of recognized people.
+    /// </summary>
+    public async Task<PeopleResponse?> GetPeopleAsync(
+        bool? withHidden,
+        int? page,
+        int? size,
+        CancellationToken cancellationToken = default)
+    {
+        var queryParams = new List<string>();
+        if (withHidden.HasValue) queryParams.Add($"withHidden={withHidden.Value.ToString().ToLower()}");
+        if (page.HasValue) queryParams.Add($"page={page.Value}");
+        if (size.HasValue) queryParams.Add($"size={size.Value}");
+
+        var url = queryParams.Count > 0
+            ? $"api/people?{string.Join("&", queryParams)}"
             : "api/people";
 
         return await GetAsync<PeopleResponse>(url, cancellationToken).ConfigureAwait(false);
@@ -503,7 +532,28 @@ public class ImmichClient
     /// </summary>
     public async Task<List<Asset>> GetPersonAssetsAsync(string personId, CancellationToken cancellationToken = default)
     {
-        return await GetAsync<List<Asset>>($"api/people/{personId}/assets", cancellationToken).ConfigureAwait(false) ?? [];
+        var result = await SearchPersonAssetsAsync(personId, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return result.Items;
+    }
+
+    /// <summary>
+    /// Searches assets associated with a person using Immich's metadata search endpoint.
+    /// </summary>
+    public async Task<SearchAssetResult<Asset>> SearchPersonAssetsAsync(
+        string personId,
+        int? page = null,
+        int? size = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await SearchMetadataAsync(
+            new MetadataSearchRequest
+            {
+                PersonIds = [personId],
+                Page = page,
+                Size = size,
+                WithExif = true
+            },
+            cancellationToken).ConfigureAwait(false);
     }
 
     #endregion
@@ -625,16 +675,16 @@ public class ImmichClient
     /// <summary>
     /// Adds assets to a shared link.
     /// </summary>
-    public async Task<List<BulkIdResponse>?> AddAssetsToSharedLinkAsync(string linkId, string[] assetIds, CancellationToken cancellationToken = default)
+    public async Task<List<AssetIdResponse>?> AddAssetsToSharedLinkAsync(string linkId, string[] assetIds, CancellationToken cancellationToken = default)
     {
         var request = new { ids = assetIds };
-        return await PutAsync<List<BulkIdResponse>>($"api/shared-links/{linkId}/assets", request, cancellationToken).ConfigureAwait(false);
+        return await PutAsync<List<AssetIdResponse>>($"api/shared-links/{linkId}/assets", request, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
     /// Removes assets from a shared link.
     /// </summary>
-    public async Task<List<BulkIdResponse>?> RemoveAssetsFromSharedLinkAsync(string linkId, string[] assetIds, CancellationToken cancellationToken = default)
+    public async Task<List<AssetIdResponse>?> RemoveAssetsFromSharedLinkAsync(string linkId, string[] assetIds, CancellationToken cancellationToken = default)
     {
         var request = new HttpRequestMessage(HttpMethod.Delete, $"api/shared-links/{linkId}/assets")
         {
@@ -644,7 +694,7 @@ public class ImmichClient
 
         if (response.IsSuccessStatusCode)
         {
-            return await response.Content.ReadFromJsonAsync<List<BulkIdResponse>>(JsonOptions, cancellationToken).ConfigureAwait(false);
+            return await response.Content.ReadFromJsonAsync<List<AssetIdResponse>>(JsonOptions, cancellationToken).ConfigureAwait(false);
         }
 
         throw await ImmichApiException.FromResponseAsync(response, "DELETE", $"api/shared-links/{linkId}/assets", cancellationToken).ConfigureAwait(false);
@@ -811,6 +861,21 @@ public record BulkIdResponse
 }
 
 /// <summary>
+/// Response for shared-link asset membership operations.
+/// </summary>
+public record AssetIdResponse
+{
+    [JsonPropertyName("assetId")]
+    public string AssetId { get; init; } = string.Empty;
+
+    [JsonPropertyName("success")]
+    public bool Success { get; init; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; init; }
+}
+
+/// <summary>
 /// Server information.
 /// </summary>
 public record ServerInfo
@@ -842,7 +907,7 @@ public record ServerFeatures
     public bool Trash { get; init; }
     public bool Map { get; init; }
     public bool ReverseGeocoding { get; init; }
-    public bool Import { get; init; }
+    public bool ImportFaces { get; init; }
     public bool Sidecar { get; init; }
     public bool Search { get; init; }
     public bool FacialRecognition { get; init; }
@@ -853,4 +918,6 @@ public record ServerFeatures
     public bool DuplicateDetection { get; init; }
     public bool Email { get; init; }
     public bool SmartSearch { get; init; }
+    public bool Ocr { get; init; }
+    public bool RealtimeTranscoding { get; init; }
 }

--- a/ImmichMCP/Models/Activities/Activity.cs
+++ b/ImmichMCP/Models/Activities/Activity.cs
@@ -69,6 +69,9 @@ public record ActivityStatistics
 {
     [JsonPropertyName("comments")]
     public int Comments { get; init; }
+
+    [JsonPropertyName("likes")]
+    public int Likes { get; init; }
 }
 
 /// <summary>

--- a/ImmichMCP/Models/Albums/Album.cs
+++ b/ImmichMCP/Models/Albums/Album.cs
@@ -160,8 +160,8 @@ public record AlbumContributorCount
     [JsonPropertyName("userId")]
     public string UserId { get; init; } = string.Empty;
 
-    [JsonPropertyName("count")]
-    public int Count { get; init; }
+    [JsonPropertyName("assetCount")]
+    public int AssetCount { get; init; }
 }
 
 /// <summary>

--- a/ImmichMCP/Models/Assets/Asset.cs
+++ b/ImmichMCP/Models/Assets/Asset.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using ImmichMCP.Utils;
 
 namespace ImmichMCP.Models.Assets;
 
@@ -62,6 +63,7 @@ public record Asset
     public bool HasMetadata { get; init; }
 
     [JsonPropertyName("duration")]
+    [JsonConverter(typeof(DurationMillisecondsJsonConverter))]
     public int? Duration { get; init; }
 
     [JsonPropertyName("visibility")]
@@ -222,6 +224,18 @@ public record AssetStatistics
 
     [JsonPropertyName("total")]
     public int Total { get; init; }
+}
+
+/// <summary>
+/// Response returned when an asset upload is accepted.
+/// </summary>
+public record AssetMediaResponse
+{
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = string.Empty;
+
+    [JsonPropertyName("status")]
+    public string Status { get; init; } = string.Empty;
 }
 
 /// <summary>

--- a/ImmichMCP/Models/People/Person.cs
+++ b/ImmichMCP/Models/People/Person.cs
@@ -37,11 +37,14 @@ public record PeopleResponse
     [JsonPropertyName("total")]
     public int Total { get; init; }
 
-    [JsonPropertyName("visible")]
-    public int Visible { get; init; }
-
     [JsonPropertyName("hidden")]
     public int Hidden { get; init; }
+
+    [JsonPropertyName("hasNextPage")]
+    public bool HasNextPage { get; init; }
+
+    [JsonIgnore]
+    public int Visible => Math.Max(0, Total - Hidden);
 }
 
 /// <summary>

--- a/ImmichMCP/Models/Tags/Tag.cs
+++ b/ImmichMCP/Models/Tags/Tag.cs
@@ -43,9 +43,6 @@ public record TagCreateRequest
 /// </summary>
 public record TagUpdateRequest
 {
-    [JsonPropertyName("name")]
-    public string? Name { get; init; }
-
     [JsonPropertyName("color")]
     public string? Color { get; init; }
 }

--- a/ImmichMCP/Tools/ActivityTools.cs
+++ b/ImmichMCP/Tools/ActivityTools.cs
@@ -161,7 +161,7 @@ public static class ActivityTools
     }
 
     [McpServerTool(Name = "immich_activities_statistics")]
-    [Description("Get activity statistics (comment count) for an album or asset.")]
+    [Description("Get activity statistics (comment and like counts) for an album or asset.")]
     public static async Task<string> Statistics(
         ImmichClient client,
         [Description("Album ID (UUID)")] string albumId,
@@ -194,7 +194,8 @@ public static class ActivityTools
             {
                 album_id = albumId,
                 asset_id = assetId,
-                comments = stats.Comments
+                comments = stats.Comments,
+                likes = stats.Likes
             },
             new McpMeta { ImmichBaseUrl = client.BaseUrl }
         );

--- a/ImmichMCP/Tools/HealthTools.cs
+++ b/ImmichMCP/Tools/HealthTools.cs
@@ -59,22 +59,25 @@ public static class HealthTools
                 features!.Trash,
                 features.Map,
                 features.ReverseGeocoding,
-                features.Import,
+                features.ImportFaces,
                 features.Sidecar,
                 features.Search,
                 features.FacialRecognition,
                 features.Oauth,
+                features.OauthAutoLaunch,
                 features.PasswordLogin,
                 features.ConfigFile,
                 features.DuplicateDetection,
                 features.Email,
-                features.SmartSearch
+                features.SmartSearch,
+                features.Ocr,
+                features.RealtimeTranscoding
             } : null,
             endpoints = new
             {
                 assets = new
                 {
-                    list = "/api/assets",
+                    list = "/api/search/metadata",
                     get = "/api/assets/{id}",
                     upload = "/api/assets",
                     update = "/api/assets/{id}",
@@ -107,7 +110,7 @@ public static class HealthTools
                     get = "/api/people/{id}",
                     update = "/api/people/{id}",
                     merge = "/api/people/{id}/merge",
-                    assets = "/api/people/{id}/assets"
+                    assets = "/api/search/metadata"
                 },
                 tags = new
                 {

--- a/ImmichMCP/Tools/PeopleTools.cs
+++ b/ImmichMCP/Tools/PeopleTools.cs
@@ -23,7 +23,10 @@ public static class PeopleTools
         [Description("Page number (default: 1)")] int page = 1,
         [Description("Page size (default: 25, max: 100)")] int size = 25)
     {
-        var result = await client.GetPeopleAsync(withHidden).ConfigureAwait(false);
+        size = Math.Min(Math.Max(size, 1), 100);
+        page = Math.Max(page, 1);
+
+        var result = await client.GetPeopleAsync(withHidden, page, size).ConfigureAwait(false);
 
         if (result == null)
         {
@@ -35,22 +38,11 @@ public static class PeopleTools
             return JsonSerializer.Serialize(errorResponse);
         }
 
-        // Enforce pagination limits
-        size = Math.Min(Math.Max(size, 1), 100);
-        page = Math.Max(page, 1);
-
-        var allPeople = result.People;
-        var totalCount = allPeople.Count;
-        var skip = (page - 1) * size;
-
-        // Apply pagination
-        var pagedPeople = allPeople
-            .Skip(skip)
-            .Take(size)
+        var pagedPeople = result.People
             .Select(p => PersonSummary.FromPerson(p))
             .ToList();
 
-        var hasMore = skip + pagedPeople.Count < totalCount;
+        var hasMore = result.HasNextPage || (long)page * size < result.Total;
         var nextPage = hasMore ? $"page={page + 1}&size={size}" : null;
 
         var response = McpResponse<object>.Success(
@@ -64,7 +56,7 @@ public static class PeopleTools
             {
                 Page = page,
                 PageSize = size,
-                Total = totalCount,
+                Total = result.Total,
                 Next = nextPage,
                 ImmichBaseUrl = client.BaseUrl
             }
@@ -218,24 +210,14 @@ public static class PeopleTools
         [Description("Page number (default: 1)")] int page = 1,
         [Description("Page size (default: 25, max: 100)")] int size = 25)
     {
-        var assets = await client.GetPersonAssetsAsync(personId).ConfigureAwait(false);
-
-        // Enforce pagination limits
         size = Math.Min(Math.Max(size, 1), 100);
         page = Math.Max(page, 1);
 
-        var totalCount = assets.Count;
-        var skip = (page - 1) * size;
+        var result = await client.SearchPersonAssetsAsync(personId, page, size).ConfigureAwait(false);
 
-        // Apply pagination
-        var pagedAssets = assets
-            .Skip(skip)
-            .Take(size)
+        var pagedAssets = result.Items
             .Select(AssetSummary.FromAsset)
             .ToList();
-
-        var hasMore = skip + pagedAssets.Count < totalCount;
-        var nextPage = hasMore ? $"page={page + 1}&size={size}" : null;
 
         var response = McpResponse<object>.Success(
             pagedAssets,
@@ -243,8 +225,8 @@ public static class PeopleTools
             {
                 Page = page,
                 PageSize = size,
-                Total = totalCount,
-                Next = nextPage,
+                Total = result.Total,
+                Next = result.NextPage,
                 ImmichBaseUrl = client.BaseUrl
             }
         );

--- a/ImmichMCP/Tools/TagTools.cs
+++ b/ImmichMCP/Tools/TagTools.cs
@@ -101,16 +101,14 @@ public static class TagTools
     }
 
     [McpServerTool(Name = "immich_tags_update")]
-    [Description("Update a tag.")]
+    [Description("Update a tag's color.")]
     public static async Task<string> Update(
         ImmichClient client,
         [Description("Tag ID (UUID)")] string id,
-        [Description("New tag name")] string? name = null,
         [Description("New tag color (hex, e.g., '#ff0000')")] string? color = null)
     {
         var request = new TagUpdateRequest
         {
-            Name = name,
             Color = color
         };
 

--- a/ImmichMCP/Utils/DurationMillisecondsJsonConverter.cs
+++ b/ImmichMCP/Utils/DurationMillisecondsJsonConverter.cs
@@ -1,0 +1,61 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ImmichMCP.Utils;
+
+/// <summary>
+/// Reads the Immich v3 duration contract (integer milliseconds) while also
+/// accepting the legacy v2 timespan string representation.
+/// </summary>
+public sealed class DurationMillisecondsJsonConverter : JsonConverter<int?>
+{
+    public override int? Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            return null;
+        }
+
+        if (reader.TokenType == JsonTokenType.Number &&
+            reader.TryGetInt32(out var milliseconds) &&
+            milliseconds >= 0)
+        {
+            return milliseconds;
+        }
+
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            var value = reader.GetString();
+            if (TimeSpan.TryParse(value, CultureInfo.InvariantCulture, out var duration) &&
+                duration >= TimeSpan.Zero)
+            {
+                var durationMilliseconds = duration.Ticks / TimeSpan.TicksPerMillisecond;
+                if (durationMilliseconds <= int.MaxValue)
+                {
+                    return (int)durationMilliseconds;
+                }
+            }
+        }
+
+        throw new JsonException("Asset duration must be non-negative integer milliseconds or a timespan string.");
+    }
+
+    public override void Write(
+        Utf8JsonWriter writer,
+        int? value,
+        JsonSerializerOptions options)
+    {
+        if (value.HasValue)
+        {
+            writer.WriteNumberValue(value.Value);
+        }
+        else
+        {
+            writer.WriteNullValue();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- accept both legacy Immich v2 timespan strings and v3 integer milliseconds for asset durations, normalizing to milliseconds
- deserialize upload media responses correctly and fetch the complete uploaded asset
- replace the nonexistent person-assets endpoint with paginated metadata search
- align people, album contributor, activity, shared-link, tag, server-feature, and capability contracts with Immich v3.0.2
- add raw upstream-shaped regression fixtures instead of circular DTO-generated payloads

## Root cause

Immich v3 intentionally changed `asset.duration` from a timespan string to integer milliseconds, while issue #17 was reported against Immich v2.7.5. A simple `int?` to `string?` change would fix v2 but regress every supported v3 asset response. Other client models had also drifted from renamed fields and endpoint response shapes.

## TDD verification

- 11 focused contract tests failed before the production changes for the expected reasons
- all 11 focused tests pass after the fixes
- full suite: 76 passed, 0 warnings
- Release build: 0 errors, 0 warnings
- Immich v3.0.2 schema audit: 0 primitive type mismatches
- `git diff --check`: clean

Refs #17