### PR TITLE
feat: implement DOWNLOAD_MODE=base64 for asset download tools

### DIFF
--- a/ImmichMCP.Tests/Fixtures/MockHttpClientFactory.cs
+++ b/ImmichMCP.Tests/Fixtures/MockHttpClientFactory.cs
@@ -10,7 +10,9 @@ public static class MockHttpClientFactory
 {
     public static (ImmichClient Client, MockHttpMessageHandler Handler) CreateMockClient(
         string baseUrl = "https://photos.example.com",
-        string apiKey = "test-api-key")
+        string apiKey = "test-api-key",
+        string downloadMode = "url",
+        long maxInlineDownloadBytes = 25 * 1024 * 1024)
     {
         var mockHandler = new MockHttpMessageHandler();
         var httpClient = mockHandler.ToHttpClient();
@@ -22,7 +24,8 @@ public static class MockHttpClientFactory
             BaseUrl = baseUrl,
             ApiKey = apiKey,
             MaxPageSize = 100,
-            DownloadMode = "url"
+            DownloadMode = downloadMode,
+            MaxInlineDownloadBytes = maxInlineDownloadBytes
         });
 
         var logger = new LoggerFactory().CreateLogger<ImmichClient>();

--- a/ImmichMCP.Tests/Integration/ToolCoverageIntegrationTests.cs
+++ b/ImmichMCP.Tests/Integration/ToolCoverageIntegrationTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using FluentAssertions;
 using Microsoft.Extensions.Options;
+using ModelContextProtocol.Protocol;
 using ImmichMCP.Client;
 using ImmichMCP.Configuration;
 using ImmichMCP.Services;
@@ -77,6 +78,9 @@ public class ToolCoverageIntegrationTests
         string? tagId = null;
 
         static string Trunc(string s) => s.Length > 180 ? s[..180] + "…" : s;
+
+        static string FirstText(CallToolResult result) =>
+            result.Content.OfType<TextContentBlock>().First().Text;
 
         async Task<JsonElement?> Ok(string name, Func<Task<string>> call, Func<JsonElement, bool>? assert = null)
         {
@@ -238,8 +242,8 @@ public class ToolCoverageIntegrationTests
             {
                 await Ok("immich_assets_get", () => AssetTools.Get(client, asset1));
                 await Ok("immich_assets_exif", () => AssetTools.GetExif(client, asset1));
-                await Ok("immich_assets_download_original", () => AssetTools.DownloadOriginal(client, asset1));
-                await Ok("immich_assets_download_thumbnail", () => AssetTools.DownloadThumbnail(client, asset1));
+                await Ok("immich_assets_download_original", async () => FirstText(await AssetTools.DownloadOriginal(client, asset1)));
+                await Ok("immich_assets_download_thumbnail", async () => FirstText(await AssetTools.DownloadThumbnail(client, asset1)));
                 await Ok("immich_assets_update", () => AssetTools.Update(client, asset1, isFavorite: true, description: "mcp tool test"));
                 await Ok("immich_assets_bulk_update", () => AssetTools.BulkUpdate(client, asset1, isFavorite: false, dryRun: false, confirm: true));
             }

--- a/ImmichMCP.Tests/Tools/AssetDownloadToolTests.cs
+++ b/ImmichMCP.Tests/Tools/AssetDownloadToolTests.cs
@@ -1,0 +1,227 @@
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using ModelContextProtocol.Protocol;
+using RichardSzalay.MockHttp;
+using ImmichMCP.Client;
+using ImmichMCP.Tests.Fixtures;
+using ImmichMCP.Tools;
+
+namespace ImmichMCP.Tests.Tools;
+
+public class AssetDownloadToolTests
+{
+    private const string AssetId = "asset-1";
+
+    private static void MockAssetGet(MockHttpMessageHandler handler, string originalFileName = "photo.jpg", string type = "IMAGE")
+    {
+        var asset = TestFixtures.CreateAsset(id: AssetId, type: type, originalFileName: originalFileName);
+        handler.When(HttpMethod.Get, $"*/assets/{AssetId}")
+            .Respond("application/json", TestFixtures.ToJson(asset));
+    }
+
+    private static JsonDocument ParseEnvelope(CallToolResult result) =>
+        JsonDocument.Parse(result.Content.OfType<TextContentBlock>().First().Text);
+
+    private static byte[] DecodeBase64Payload(IEnumerable<byte> payload) =>
+        Convert.FromBase64String(System.Text.Encoding.ASCII.GetString(payload.ToArray()));
+
+    [Fact]
+    public async Task DownloadThumbnail_ReturnsInlineImage_WhenBase64Mode()
+    {
+        // Arrange
+        var (client, handler) = MockHttpClientFactory.CreateMockClient(downloadMode: "base64");
+        MockAssetGet(handler);
+        var imageBytes = new byte[] { 0xFF, 0xD8, 0xFF, 0xE0, 0x01, 0x02, 0x03 };
+        handler.When(HttpMethod.Get, $"*/assets/{AssetId}/thumbnail")
+            .WithQueryString("size", "preview")
+            .Respond("image/jpeg", new MemoryStream(imageBytes));
+
+        // Act
+        var result = await AssetTools.DownloadThumbnail(client, AssetId);
+
+        // Assert
+        using var json = ParseEnvelope(result);
+        json.RootElement.GetProperty("ok").GetBoolean().Should().BeTrue();
+        json.RootElement.GetProperty("result").GetProperty("encoding").GetString().Should().Be("base64");
+
+        var image = result.Content.OfType<ImageContentBlock>().Should().ContainSingle().Subject;
+        image.MimeType.Should().Be("image/jpeg");
+        DecodeBase64Payload(image.Data.ToArray()).Should().Equal(imageBytes);
+    }
+
+    [Fact]
+    public async Task DownloadOriginal_ReturnsEmbeddedBlob_WhenBase64ModeAndNonImage()
+    {
+        // Arrange
+        var (client, handler) = MockHttpClientFactory.CreateMockClient(downloadMode: "base64");
+        MockAssetGet(handler, originalFileName: "clip.mp4", type: "VIDEO");
+        var videoBytes = new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04 };
+        handler.When(HttpMethod.Get, $"*/assets/{AssetId}/original")
+            .Respond("video/mp4", new MemoryStream(videoBytes));
+
+        // Act
+        var result = await AssetTools.DownloadOriginal(client, AssetId);
+
+        // Assert
+        using var json = ParseEnvelope(result);
+        json.RootElement.GetProperty("ok").GetBoolean().Should().BeTrue();
+        json.RootElement.GetProperty("result").GetProperty("mime_type").GetString().Should().Be("video/mp4");
+
+        result.Content.OfType<ImageContentBlock>().Should().BeEmpty();
+        var resource = result.Content.OfType<EmbeddedResourceBlock>().Should().ContainSingle().Subject;
+        var blob = resource.Resource.Should().BeOfType<BlobResourceContents>().Subject;
+        blob.MimeType.Should().Be("video/mp4");
+        DecodeBase64Payload(blob.Blob.ToArray()).Should().Equal(videoBytes);
+    }
+
+    [Fact]
+    public async Task DownloadOriginal_ReturnsUrlJsonOnly_WhenUrlMode()
+    {
+        // Arrange
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        MockAssetGet(handler);
+
+        // Act
+        var result = await AssetTools.DownloadOriginal(client, AssetId);
+
+        // Assert: URL mode behavior is unchanged — one text block, no binary content.
+        result.Content.Should().ContainSingle().Which.Should().BeOfType<TextContentBlock>();
+        using var json = ParseEnvelope(result);
+        json.RootElement.GetProperty("ok").GetBoolean().Should().BeTrue();
+        json.RootElement.GetProperty("result").GetProperty("original_url").GetString()
+            .Should().Be($"https://photos.example.com/api/assets/{AssetId}/original");
+    }
+
+    [Fact]
+    public async Task DownloadThumbnail_ReturnsUrlJsonOnly_WhenUrlMode()
+    {
+        // Arrange
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        MockAssetGet(handler);
+
+        // Act
+        var result = await AssetTools.DownloadThumbnail(client, AssetId);
+
+        // Assert
+        result.Content.Should().ContainSingle().Which.Should().BeOfType<TextContentBlock>();
+        using var json = ParseEnvelope(result);
+        json.RootElement.GetProperty("result").GetProperty("preview_url").GetString()
+            .Should().Be($"https://photos.example.com/api/assets/{AssetId}/thumbnail?size=preview");
+    }
+
+    [Fact]
+    public async Task DownloadOriginal_Throws_WhenUpstreamFails()
+    {
+        // Arrange
+        var (client, handler) = MockHttpClientFactory.CreateMockClient(downloadMode: "base64");
+        MockAssetGet(handler);
+        handler.When(HttpMethod.Get, $"*/assets/{AssetId}/original")
+            .Respond(HttpStatusCode.InternalServerError);
+
+        // Act
+        var act = () => AssetTools.DownloadOriginal(client, AssetId);
+
+        // Assert
+        await act.Should().ThrowAsync<ImmichApiException>();
+    }
+
+    [Fact]
+    public async Task DownloadOriginal_ReturnsPayloadTooLargeError_WhenContentLengthExceedsCap()
+    {
+        // Arrange
+        var (client, handler) = MockHttpClientFactory.CreateMockClient(downloadMode: "base64", maxInlineDownloadBytes: 4);
+        MockAssetGet(handler);
+        handler.When(HttpMethod.Get, $"*/assets/{AssetId}/original")
+            .Respond("image/jpeg", new MemoryStream(new byte[64]));
+
+        // Act
+        var result = await AssetTools.DownloadOriginal(client, AssetId);
+
+        // Assert: clear error instead of inline content, pointing at the URL fallback.
+        result.Content.Should().ContainSingle().Which.Should().BeOfType<TextContentBlock>();
+        using var json = ParseEnvelope(result);
+        json.RootElement.GetProperty("ok").GetBoolean().Should().BeFalse();
+        var error = json.RootElement.GetProperty("error");
+        error.GetProperty("code").GetString().Should().Be("PAYLOAD_TOO_LARGE");
+        error.GetProperty("details").GetProperty("max_inline_download_bytes").GetInt64().Should().Be(4);
+        error.GetProperty("details").GetProperty("download_url").GetString()
+            .Should().Be($"https://photos.example.com/api/assets/{AssetId}/original");
+    }
+
+    [Fact]
+    public async Task DownloadThumbnail_ReturnsPayloadTooLargeError_WhenBodyExceedsCapWithoutContentLength()
+    {
+        // Arrange: chunked-style response (no Content-Length), so the cap must be
+        // enforced by the bounded read rather than the header check.
+        var (client, handler) = MockHttpClientFactory.CreateMockClient(downloadMode: "base64", maxInlineDownloadBytes: 4);
+        MockAssetGet(handler);
+        handler.When(HttpMethod.Get, $"*/assets/{AssetId}/thumbnail")
+            .WithQueryString("size", "preview")
+            .Respond(_ =>
+            {
+                var content = new ByteArrayContent(new byte[64]);
+                content.Headers.ContentLength = null;
+                content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("image/jpeg");
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+            });
+
+        // Act
+        var result = await AssetTools.DownloadThumbnail(client, AssetId);
+
+        // Assert
+        result.Content.Should().ContainSingle().Which.Should().BeOfType<TextContentBlock>();
+        using var json = ParseEnvelope(result);
+        json.RootElement.GetProperty("ok").GetBoolean().Should().BeFalse();
+        json.RootElement.GetProperty("error").GetProperty("code").GetString().Should().Be("PAYLOAD_TOO_LARGE");
+    }
+
+    [Fact]
+    public async Task DownloadOriginal_Throws_WhenAlreadyCanceled()
+    {
+        // Arrange
+        var (client, handler) = MockHttpClientFactory.CreateMockClient(downloadMode: "base64");
+        MockAssetGet(handler);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act
+        var act = () => AssetTools.DownloadOriginal(client, AssetId, cts.Token);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task DownloadThumbnail_Throws_WhenUpstreamFails()
+    {
+        // Arrange
+        var (client, handler) = MockHttpClientFactory.CreateMockClient(downloadMode: "base64");
+        MockAssetGet(handler);
+        handler.When(HttpMethod.Get, $"*/assets/{AssetId}/thumbnail")
+            .WithQueryString("size", "preview")
+            .Respond(HttpStatusCode.InternalServerError);
+
+        // Act
+        var act = () => AssetTools.DownloadThumbnail(client, AssetId);
+
+        // Assert
+        await act.Should().ThrowAsync<ImmichApiException>();
+    }
+
+    [Fact]
+    public async Task DownloadThumbnail_Throws_WhenAlreadyCanceled()
+    {
+        // Arrange
+        var (client, handler) = MockHttpClientFactory.CreateMockClient(downloadMode: "base64");
+        MockAssetGet(handler);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Act
+        var act = () => AssetTools.DownloadThumbnail(client, AssetId, cts.Token);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}

--- a/ImmichMCP/Client/ImmichClient.cs
+++ b/ImmichMCP/Client/ImmichClient.cs
@@ -810,16 +810,40 @@ public class ImmichClient
 
     private async Task<(byte[] Bytes, string MimeType)> DownloadBytesAsync(string url, CancellationToken cancellationToken)
     {
-        var response = await _httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+        var maxBytes = _options.MaxInlineDownloadBytes;
+
+        using var response = await _httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
 
         if (!response.IsSuccessStatusCode)
         {
             throw await ImmichApiException.FromResponseAsync(response, "GET", url, cancellationToken).ConfigureAwait(false);
         }
 
-        var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+        var contentLength = response.Content.Headers.ContentLength;
+        if (contentLength > maxBytes)
+        {
+            throw new InlineDownloadTooLargeException(url, contentLength, maxBytes);
+        }
+
         var mimeType = response.Content.Headers.ContentType?.MediaType ?? "application/octet-stream";
-        return (bytes, mimeType);
+
+        // Bounded read: Content-Length can be absent (chunked) or lie, so never
+        // buffer more than the cap regardless of what the headers said.
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        using var buffer = new MemoryStream();
+        var chunk = new byte[81920];
+        int read;
+        while ((read = await stream.ReadAsync(chunk, cancellationToken).ConfigureAwait(false)) > 0)
+        {
+            if (buffer.Length + read > maxBytes)
+            {
+                throw new InlineDownloadTooLargeException(url, contentLength, maxBytes);
+            }
+
+            buffer.Write(chunk, 0, read);
+        }
+
+        return (buffer.ToArray(), mimeType);
     }
 
     private async Task<T?> GetAsync<T>(string url, CancellationToken cancellationToken)

--- a/ImmichMCP/Client/ImmichClient.cs
+++ b/ImmichMCP/Client/ImmichClient.cs
@@ -44,6 +44,8 @@ public class ImmichClient
 
     public string BaseUrl => _options.BaseUrl;
 
+    public string DownloadMode => _options.DownloadMode;
+
     #region Health & Status
 
     /// <summary>
@@ -324,6 +326,18 @@ public class ImmichClient
             PreviewUrl = $"{baseUrl}/api/assets/{id}/thumbnail?size=preview"
         };
     }
+
+    /// <summary>
+    /// Downloads the preview-size thumbnail bytes for an asset.
+    /// </summary>
+    public async Task<(byte[] Bytes, string MimeType)> DownloadAssetThumbnailAsync(string id, CancellationToken cancellationToken = default)
+        => await DownloadBytesAsync($"api/assets/{id}/thumbnail?size=preview", cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Downloads the original file bytes for an asset.
+    /// </summary>
+    public async Task<(byte[] Bytes, string MimeType)> DownloadAssetOriginalAsync(string id, CancellationToken cancellationToken = default)
+        => await DownloadBytesAsync($"api/assets/{id}/original", cancellationToken).ConfigureAwait(false);
 
     #endregion
 
@@ -793,6 +807,20 @@ public class ImmichClient
     // MCP boundary can report a spec-compliant tool execution error (isError: true).
     // The single deliberate exception is 404 on a get-by-id, which is a legitimate
     // "not found" result the caller maps to a NOT_FOUND response.
+
+    private async Task<(byte[] Bytes, string MimeType)> DownloadBytesAsync(string url, CancellationToken cancellationToken)
+    {
+        var response = await _httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw await ImmichApiException.FromResponseAsync(response, "GET", url, cancellationToken).ConfigureAwait(false);
+        }
+
+        var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+        var mimeType = response.Content.Headers.ContentType?.MediaType ?? "application/octet-stream";
+        return (bytes, mimeType);
+    }
 
     private async Task<T?> GetAsync<T>(string url, CancellationToken cancellationToken)
     {

--- a/ImmichMCP/Client/InlineDownloadTooLargeException.cs
+++ b/ImmichMCP/Client/InlineDownloadTooLargeException.cs
@@ -1,0 +1,25 @@
+namespace ImmichMCP.Client;
+
+/// <summary>
+/// Thrown when an asset exceeds the configured inline download size cap
+/// (MAX_INLINE_DOWNLOAD_BYTES) while DOWNLOAD_MODE=base64. The caller should
+/// surface a clear error pointing at the download URL instead of buffering
+/// arbitrarily large files into memory.
+/// </summary>
+public sealed class InlineDownloadTooLargeException : Exception
+{
+    /// <summary>Reported Content-Length, or null when the response was chunked.</summary>
+    public long? ContentLength { get; }
+
+    /// <summary>The configured inline size cap in bytes.</summary>
+    public long MaxInlineDownloadBytes { get; }
+
+    public InlineDownloadTooLargeException(string path, long? contentLength, long maxInlineDownloadBytes)
+        : base(contentLength is long len
+            ? $"Asset at {path} is {len} bytes, which exceeds the inline download limit of {maxInlineDownloadBytes} bytes (MAX_INLINE_DOWNLOAD_BYTES). Fetch it via the download URL instead, or raise the limit."
+            : $"Asset at {path} exceeds the inline download limit of {maxInlineDownloadBytes} bytes (MAX_INLINE_DOWNLOAD_BYTES). Fetch it via the download URL instead, or raise the limit.")
+    {
+        ContentLength = contentLength;
+        MaxInlineDownloadBytes = maxInlineDownloadBytes;
+    }
+}

--- a/ImmichMCP/Configuration/ImmichOptions.cs
+++ b/ImmichMCP/Configuration/ImmichOptions.cs
@@ -24,4 +24,9 @@ public class ImmichOptions
     /// Download mode: "url" returns URLs, "base64" returns encoded content.
     /// </summary>
     public string DownloadMode { get; set; } = "url";
+
+    /// <summary>
+    /// Maximum asset size (in bytes) returned inline when DownloadMode is "base64".
+    /// </summary>
+    public long MaxInlineDownloadBytes { get; set; } = 25 * 1024 * 1024;
 }

--- a/ImmichMCP/Models/Common/McpResponse.cs
+++ b/ImmichMCP/Models/Common/McpResponse.cs
@@ -114,4 +114,5 @@ public static class ErrorCodes
     public const string RateLimit = "RATE_LIMIT";
     public const string Unknown = "UNKNOWN";
     public const string ConfirmationRequired = "CONFIRMATION_REQUIRED";
+    public const string PayloadTooLarge = "PAYLOAD_TOO_LARGE";
 }

--- a/ImmichMCP/Program.cs
+++ b/ImmichMCP/Program.cs
@@ -188,6 +188,10 @@ void ConfigureServices(IServiceCollection services, IConfiguration configuration
         options.DownloadMode = Environment.GetEnvironmentVariable("DOWNLOAD_MODE")
                                ?? configuration.GetValue<string>("Immich:DownloadMode")
                                ?? "url";
+
+        options.MaxInlineDownloadBytes = Environment.GetEnvironmentVariable("MAX_INLINE_DOWNLOAD_BYTES") is string maxInlineStr && long.TryParse(maxInlineStr, out var maxInline)
+            ? maxInline
+            : configuration.GetValue<long?>("Immich:MaxInlineDownloadBytes") ?? 25 * 1024 * 1024;
     });
 
     // Configure retry policy for transient errors

--- a/ImmichMCP/Tools/AssetTools.cs
+++ b/ImmichMCP/Tools/AssetTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
+using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using ImmichMCP.Client;
 using ImmichMCP.Models.Common;
@@ -207,8 +208,8 @@ public static class AssetTools
     }
 
     [McpServerTool(Name = "immich_assets_download_original")]
-    [Description("Get download URL for the original asset file.")]
-    public static async Task<string> DownloadOriginal(
+    [Description("Get the original asset file. Returns a download URL, or the file content inline when DOWNLOAD_MODE=base64.")]
+    public static async Task<CallToolResult> DownloadOriginal(
         ImmichClient client,
         [Description("Asset ID (UUID)")] string id)
     {
@@ -216,33 +217,46 @@ public static class AssetTools
 
         if (asset == null)
         {
-            var errorResponse = McpErrorResponse.Create(
-                ErrorCodes.NotFound,
-                $"Asset with ID {id} not found",
-                meta: new McpMeta { ImmichBaseUrl = client.BaseUrl }
-            );
-            return JsonSerializer.Serialize(errorResponse);
+            return AssetNotFoundResult(id, client);
         }
 
         var downloadInfo = client.GetAssetDownloadInfo(id, asset.OriginalFileName);
+
+        if (!IsBase64Mode(client))
+        {
+            var urlResponse = McpResponse<object>.Success(
+                new
+                {
+                    id,
+                    original_file_name = asset.OriginalFileName,
+                    original_url = downloadInfo.OriginalUrl,
+                    mime_type = asset.OriginalMimeType,
+                    file_size = asset.ExifInfo?.FileSizeInByte
+                },
+                new McpMeta { ImmichBaseUrl = client.BaseUrl }
+            );
+            return TextResult(JsonSerializer.Serialize(urlResponse));
+        }
+
+        var (bytes, mimeType) = await client.DownloadAssetOriginalAsync(id).ConfigureAwait(false);
 
         var response = McpResponse<object>.Success(
             new
             {
                 id,
                 original_file_name = asset.OriginalFileName,
-                original_url = downloadInfo.OriginalUrl,
-                mime_type = asset.OriginalMimeType,
-                file_size = asset.ExifInfo?.FileSizeInByte
+                mime_type = mimeType,
+                file_size = bytes.Length,
+                encoding = "base64"
             },
             new McpMeta { ImmichBaseUrl = client.BaseUrl }
         );
-        return JsonSerializer.Serialize(response);
+        return BinaryResult(JsonSerializer.Serialize(response), bytes, mimeType, downloadInfo.OriginalUrl);
     }
 
     [McpServerTool(Name = "immich_assets_download_thumbnail")]
-    [Description("Get thumbnail and preview URLs for an asset.")]
-    public static async Task<string> DownloadThumbnail(
+    [Description("Get thumbnail and preview URLs for an asset. When DOWNLOAD_MODE=base64, returns the preview image content inline instead.")]
+    public static async Task<CallToolResult> DownloadThumbnail(
         ImmichClient client,
         [Description("Asset ID (UUID)")] string id)
     {
@@ -250,28 +264,86 @@ public static class AssetTools
 
         if (asset == null)
         {
-            var errorResponse = McpErrorResponse.Create(
-                ErrorCodes.NotFound,
-                $"Asset with ID {id} not found",
-                meta: new McpMeta { ImmichBaseUrl = client.BaseUrl }
-            );
-            return JsonSerializer.Serialize(errorResponse);
+            return AssetNotFoundResult(id, client);
         }
 
         var downloadInfo = client.GetAssetDownloadInfo(id, asset.OriginalFileName);
+
+        if (!IsBase64Mode(client))
+        {
+            var urlResponse = McpResponse<object>.Success(
+                new
+                {
+                    id,
+                    original_file_name = asset.OriginalFileName,
+                    thumbnail_url = downloadInfo.ThumbnailUrl,
+                    preview_url = downloadInfo.PreviewUrl,
+                    thumbhash = asset.Thumbhash
+                },
+                new McpMeta { ImmichBaseUrl = client.BaseUrl }
+            );
+            return TextResult(JsonSerializer.Serialize(urlResponse));
+        }
+
+        var (bytes, mimeType) = await client.DownloadAssetThumbnailAsync(id).ConfigureAwait(false);
 
         var response = McpResponse<object>.Success(
             new
             {
                 id,
                 original_file_name = asset.OriginalFileName,
-                thumbnail_url = downloadInfo.ThumbnailUrl,
-                preview_url = downloadInfo.PreviewUrl,
+                mime_type = mimeType,
+                file_size = bytes.Length,
+                encoding = "base64",
                 thumbhash = asset.Thumbhash
             },
             new McpMeta { ImmichBaseUrl = client.BaseUrl }
         );
-        return JsonSerializer.Serialize(response);
+        return BinaryResult(JsonSerializer.Serialize(response), bytes, mimeType, downloadInfo.PreviewUrl);
+    }
+
+    private static bool IsBase64Mode(ImmichClient client) =>
+        string.Equals(client.DownloadMode, "base64", StringComparison.OrdinalIgnoreCase);
+
+    private static CallToolResult AssetNotFoundResult(string id, ImmichClient client) =>
+        TextResult(JsonSerializer.Serialize(McpErrorResponse.Create(
+            ErrorCodes.NotFound,
+            $"Asset with ID {id} not found",
+            meta: new McpMeta { ImmichBaseUrl = client.BaseUrl })));
+
+    private static CallToolResult TextResult(string json)
+    {
+        return new CallToolResult
+        {
+            Content =
+            [
+                new TextContentBlock
+                {
+                    Text = json
+                }
+            ]
+        };
+    }
+
+    private static CallToolResult BinaryResult(string json, byte[] bytes, string mimeType, string? uri)
+    {
+        ContentBlock binaryBlock = mimeType.StartsWith("image/", StringComparison.OrdinalIgnoreCase)
+            ? ImageContentBlock.FromBytes(bytes, mimeType)
+            : new EmbeddedResourceBlock
+            {
+                Resource = BlobResourceContents.FromBytes(bytes, uri ?? string.Empty, mimeType)
+            };
+        return new CallToolResult
+        {
+            Content =
+            [
+                new TextContentBlock
+                {
+                    Text = json
+                },
+                binaryBlock
+            ]
+        };
     }
 
     [McpServerTool(Name = "immich_assets_upload")]

--- a/ImmichMCP/Tools/AssetTools.cs
+++ b/ImmichMCP/Tools/AssetTools.cs
@@ -211,9 +211,10 @@ public static class AssetTools
     [Description("Get the original asset file. Returns a download URL, or the file content inline when DOWNLOAD_MODE=base64.")]
     public static async Task<CallToolResult> DownloadOriginal(
         ImmichClient client,
-        [Description("Asset ID (UUID)")] string id)
+        [Description("Asset ID (UUID)")] string id,
+        CancellationToken cancellationToken = default)
     {
-        var asset = await client.GetAssetAsync(id).ConfigureAwait(false);
+        var asset = await client.GetAssetAsync(id, cancellationToken).ConfigureAwait(false);
 
         if (asset == null)
         {
@@ -238,7 +239,16 @@ public static class AssetTools
             return TextResult(JsonSerializer.Serialize(urlResponse));
         }
 
-        var (bytes, mimeType) = await client.DownloadAssetOriginalAsync(id).ConfigureAwait(false);
+        byte[] bytes;
+        string mimeType;
+        try
+        {
+            (bytes, mimeType) = await client.DownloadAssetOriginalAsync(id, cancellationToken).ConfigureAwait(false);
+        }
+        catch (InlineDownloadTooLargeException ex)
+        {
+            return TooLargeResult(id, ex, downloadInfo.OriginalUrl, client);
+        }
 
         var response = McpResponse<object>.Success(
             new
@@ -258,9 +268,10 @@ public static class AssetTools
     [Description("Get thumbnail and preview URLs for an asset. When DOWNLOAD_MODE=base64, returns the preview image content inline instead.")]
     public static async Task<CallToolResult> DownloadThumbnail(
         ImmichClient client,
-        [Description("Asset ID (UUID)")] string id)
+        [Description("Asset ID (UUID)")] string id,
+        CancellationToken cancellationToken = default)
     {
-        var asset = await client.GetAssetAsync(id).ConfigureAwait(false);
+        var asset = await client.GetAssetAsync(id, cancellationToken).ConfigureAwait(false);
 
         if (asset == null)
         {
@@ -285,7 +296,16 @@ public static class AssetTools
             return TextResult(JsonSerializer.Serialize(urlResponse));
         }
 
-        var (bytes, mimeType) = await client.DownloadAssetThumbnailAsync(id).ConfigureAwait(false);
+        byte[] bytes;
+        string mimeType;
+        try
+        {
+            (bytes, mimeType) = await client.DownloadAssetThumbnailAsync(id, cancellationToken).ConfigureAwait(false);
+        }
+        catch (InlineDownloadTooLargeException ex)
+        {
+            return TooLargeResult(id, ex, downloadInfo.PreviewUrl, client);
+        }
 
         var response = McpResponse<object>.Success(
             new
@@ -309,6 +329,19 @@ public static class AssetTools
         TextResult(JsonSerializer.Serialize(McpErrorResponse.Create(
             ErrorCodes.NotFound,
             $"Asset with ID {id} not found",
+            meta: new McpMeta { ImmichBaseUrl = client.BaseUrl })));
+
+    private static CallToolResult TooLargeResult(string id, InlineDownloadTooLargeException ex, string? downloadUrl, ImmichClient client) =>
+        TextResult(JsonSerializer.Serialize(McpErrorResponse.Create(
+            ErrorCodes.PayloadTooLarge,
+            ex.Message,
+            details: new
+            {
+                id,
+                file_size = ex.ContentLength,
+                max_inline_download_bytes = ex.MaxInlineDownloadBytes,
+                download_url = downloadUrl
+            },
             meta: new McpMeta { ImmichBaseUrl = client.BaseUrl })));
 
     private static CallToolResult TextResult(string json)

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ docker run -e IMMICH_BASE_URL="https://photos.example.com" \
 | `IMMICH_API_KEY` | Yes | - | API key for authentication |
 | `MCP_LOG_LEVEL` | No | `Information` | Logging level |
 | `DOWNLOAD_MODE` | No | `url` | `url` returns URLs, `base64` returns the file content inline as MCP image/resource content |
+| `MAX_INLINE_DOWNLOAD_BYTES` | No | `26214400` | Max asset size returned inline with `DOWNLOAD_MODE=base64`; larger assets get a `PAYLOAD_TOO_LARGE` error that includes the download URL |
 | `MAX_PAGE_SIZE` | No | `100` | Maximum items per page |
 | `MCP_PORT` | No | `5000` | HTTP server port |
 | `IMMICH_TOOL_MODE` | No | `static` | `static` exposes all tools; `gateway` exposes `immich_tools_list` and `immich_tools_enable` first |

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ docker run -e IMMICH_BASE_URL="https://photos.example.com" \
 | `IMMICH_BASE_URL` | Yes | - | Base URL of your Immich instance |
 | `IMMICH_API_KEY` | Yes | - | API key for authentication |
 | `MCP_LOG_LEVEL` | No | `Information` | Logging level |
-| `DOWNLOAD_MODE` | No | `url` | `url` returns URLs, `base64` returns encoded content |
+| `DOWNLOAD_MODE` | No | `url` | `url` returns URLs, `base64` returns the file content inline as MCP image/resource content |
 | `MAX_PAGE_SIZE` | No | `100` | Maximum items per page |
 | `MCP_PORT` | No | `5000` | HTTP server port |
 | `IMMICH_TOOL_MODE` | No | `static` | `static` exposes all tools; `gateway` exposes `immich_tools_list` and `immich_tools_enable` first |
@@ -170,8 +170,8 @@ Or with Docker:
 | `immich_assets_list` | List recent assets with filters |
 | `immich_assets_get` | Get full asset metadata |
 | `immich_assets_exif` | Get EXIF data for an asset |
-| `immich_assets_download_original` | Get download URL for original |
-| `immich_assets_download_thumbnail` | Get thumbnail/preview URLs |
+| `immich_assets_download_original` | Get download URL for original (or inline content with `DOWNLOAD_MODE=base64`) |
+| `immich_assets_download_thumbnail` | Get thumbnail/preview URLs (or inline preview image with `DOWNLOAD_MODE=base64`) |
 | `immich_assets_upload` | Upload asset (base64) |
 | `immich_assets_upload_from_path` | Upload from local file path |
 | `immich_assets_upload_authorize` | Mint a short-lived, upload-only URL so a client can upload local files **directly** to Immich (no API key exposed) |


### PR DESCRIPTION
## Problem

`DOWNLOAD_MODE` is documented in the README and parsed into `ImmichOptions` (`Program.cs`), but no code ever reads `options.DownloadMode` — `immich_assets_download_original` and `immich_assets_download_thumbnail` unconditionally return URLs.

When the MCP server runs next to Immich and `IMMICH_BASE_URL` is a cluster-internal address (e.g. `http://immich-server.immich.svc.cluster.local:2283`), those URLs are unreachable from the MCP client, so there is no way for a client like Claude to actually display a photo.

## Change

With `DOWNLOAD_MODE=base64`:

- `immich_assets_download_thumbnail` fetches the preview-size thumbnail and returns it as an MCP `ImageContentBlock`, so clients render the photo inline.
- `immich_assets_download_original` returns the file inline — `ImageContentBlock` for `image/*` MIME types, an embedded blob resource otherwise.
- The existing `{"ok":true,...}` JSON envelope is still emitted as a text block alongside the binary content, and URL mode (`url`, the default) is byte-for-byte unchanged.

Implementation notes:

- `ImmichClient` gains `DownloadAssetThumbnailAsync`/`DownloadAssetOriginalAsync` following the existing HTTP-helper error convention (throw `ImmichApiException` on non-success, so the MCP boundary reports `isError`).
- The two tools now return `CallToolResult`; the gateway path (`McpServerTool.InvokeAsync` + `MarkErrorEnvelope`) is unaffected since the envelope remains the first text block.
- Content blocks are built with `ImageContentBlock.FromBytes`/`BlobResourceContents.FromBytes` so the SDK handles base64 encoding.

## Testing

- `dotnet build`: no warnings; full test suite passes (80 passed, 10 skipped live-instance tests).
- Verified end-to-end against a live Immich v2 instance over Streamable HTTP: `immich_assets_download_thumbnail` returns a valid JPEG image content block (magic bytes and dimensions checked), and Claude (web/mobile connector) renders the photo inline.
- URL mode regression-checked via the existing integration coverage (call sites updated for the `CallToolResult` return type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)