### PR TITLE
Simplify asset deletion confirmation

### DIFF
--- a/ImmichMCP.Tests/Integration/ToolCoverageIntegrationTests.cs
+++ b/ImmichMCP.Tests/Integration/ToolCoverageIntegrationTests.cs
@@ -320,9 +320,8 @@ public class ToolCoverageIntegrationTests
             // ===================== ASSETS delete tool (on a fixture) =====================
             if (asset2 is not null)
             {
-                // (dry-run intentionally returns CONFIRMATION_REQUIRED; the real delete is the tool test)
                 var del = await Ok("immich_assets_delete",
-                    () => AssetTools.Delete(client, asset2, force: true, dryRun: false, confirm: true));
+                    () => AssetTools.Delete(client, asset2, force: true, confirm: true));
                 if (del is not null) createdAssets.Remove(asset2); // deleted via the tool
             }
 

--- a/ImmichMCP.Tests/Integration/ToolCoverageIntegrationTests.cs
+++ b/ImmichMCP.Tests/Integration/ToolCoverageIntegrationTests.cs
@@ -321,7 +321,7 @@ public class ToolCoverageIntegrationTests
             if (asset2 is not null)
             {
                 var del = await Ok("immich_assets_delete",
-                    () => AssetTools.Delete(client, asset2, force: true, confirm: true));
+                    () => AssetTools.DeleteAssets(client, asset2, force: true, confirm: true));
                 if (del is not null) createdAssets.Remove(asset2); // deleted via the tool
             }
 

--- a/ImmichMCP.Tests/Tools/AssetToolsTests.cs
+++ b/ImmichMCP.Tests/Tools/AssetToolsTests.cs
@@ -42,4 +42,34 @@ public class AssetToolsTests
             .GetString().Should().Be("CONFIRMATION_REQUIRED");
         handler.VerifyNoOutstandingExpectation();
     }
+
+    [Fact]
+    public async Task DeleteAssets_StaleDryRunArgument_StillPreviews()
+    {
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        var asset = TestFixtures.CreateAsset(id: "asset-1");
+        handler.Expect(HttpMethod.Get, "*/assets/asset-1")
+            .Respond("application/json", TestFixtures.ToJson(asset));
+
+        using var result = JsonDocument.Parse(
+            await AssetTools.DeleteAssets(client, "asset-1", force: true, confirm: true, dryRun: true));
+
+        result.RootElement.GetProperty("error").GetProperty("code")
+            .GetString().Should().Be("CONFIRMATION_REQUIRED");
+        handler.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task DeleteAssets_DryRunFalseAndConfirmed_Executes()
+    {
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        handler.Expect(HttpMethod.Delete, "*/assets")
+            .Respond(HttpStatusCode.NoContent);
+
+        using var result = JsonDocument.Parse(
+            await AssetTools.DeleteAssets(client, "asset-1", confirm: true, dryRun: false));
+
+        result.RootElement.GetProperty("ok").GetBoolean().Should().BeTrue();
+        handler.VerifyNoOutstandingExpectation();
+    }
 }

--- a/ImmichMCP.Tests/Tools/AssetToolsTests.cs
+++ b/ImmichMCP.Tests/Tools/AssetToolsTests.cs
@@ -10,18 +10,36 @@ namespace ImmichMCP.Tests.Tools;
 public class AssetToolsTests
 {
     [Fact]
-    public async Task Delete_Executes_WhenConfirmed()
+    public async Task DeleteAssets_Executes_WhenConfirmed()
     {
         var (client, handler) = MockHttpClientFactory.CreateMockClient();
         handler.Expect(HttpMethod.Delete, "*/assets")
             .Respond(HttpStatusCode.NoContent);
 
         using var result = JsonDocument.Parse(
-            await AssetTools.Delete(client, "asset-1", confirm: true));
+            await AssetTools.DeleteAssets(client, "asset-1", confirm: true));
 
         result.RootElement.GetProperty("ok").GetBoolean().Should().BeTrue();
         result.RootElement.GetProperty("result").GetProperty("deleted")
             .GetBoolean().Should().BeTrue();
+        handler.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task Delete_LegacyPositionalDryRun_DoesNotDelete()
+    {
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        var asset = TestFixtures.CreateAsset(id: "asset-1");
+        handler.Expect(HttpMethod.Get, "*/assets/asset-1")
+            .Respond("application/json", TestFixtures.ToJson(asset));
+
+#pragma warning disable CS0618
+        using var result = JsonDocument.Parse(
+            await AssetTools.Delete(client, "asset-1", true, true));
+#pragma warning restore CS0618
+
+        result.RootElement.GetProperty("error").GetProperty("code")
+            .GetString().Should().Be("CONFIRMATION_REQUIRED");
         handler.VerifyNoOutstandingExpectation();
     }
 }

--- a/ImmichMCP.Tests/Tools/AssetToolsTests.cs
+++ b/ImmichMCP.Tests/Tools/AssetToolsTests.cs
@@ -1,0 +1,27 @@
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using RichardSzalay.MockHttp;
+using ImmichMCP.Tests.Fixtures;
+using ImmichMCP.Tools;
+
+namespace ImmichMCP.Tests.Tools;
+
+public class AssetToolsTests
+{
+    [Fact]
+    public async Task Delete_Executes_WhenConfirmed()
+    {
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        handler.Expect(HttpMethod.Delete, "*/assets")
+            .Respond(HttpStatusCode.NoContent);
+
+        using var result = JsonDocument.Parse(
+            await AssetTools.Delete(client, "asset-1", confirm: true));
+
+        result.RootElement.GetProperty("ok").GetBoolean().Should().BeTrue();
+        result.RootElement.GetProperty("result").GetProperty("deleted")
+            .GetBoolean().Should().BeTrue();
+        handler.VerifyNoOutstandingExpectation();
+    }
+}

--- a/ImmichMCP/Tools/AssetTools.cs
+++ b/ImmichMCP/Tools/AssetTools.cs
@@ -627,7 +627,6 @@ public static class AssetTools
         ImmichClient client,
         [Description("Asset IDs (comma-separated UUIDs)")] string assetIds,
         [Description("Force delete (bypass trash)")] bool force = false,
-        [Description("Dry run mode - shows what would be deleted without applying")] bool dryRun = true,
         [Description("Must be true to confirm deletion")] bool confirm = false)
     {
         var ids = ParseStringArray(assetIds);
@@ -642,7 +641,7 @@ public static class AssetTools
             return JsonSerializer.Serialize(errorResponse);
         }
 
-        if (dryRun || !confirm)
+        if (!confirm)
         {
             // Get asset info for dry run
             var assetInfos = new List<object>();

--- a/ImmichMCP/Tools/AssetTools.cs
+++ b/ImmichMCP/Tools/AssetTools.cs
@@ -621,9 +621,18 @@ public static class AssetTools
         return JsonSerializer.Serialize(response);
     }
 
+    [Obsolete("Use DeleteAssets instead.")]
+    public static Task<string> Delete(
+        ImmichClient client,
+        [Description("Asset IDs (comma-separated UUIDs)")] string assetIds,
+        [Description("Force delete (bypass trash)")] bool force = false,
+        [Description("Dry run mode - shows what would be deleted without applying")] bool dryRun = true,
+        [Description("Must be true to confirm deletion")] bool confirm = false)
+        => DeleteAssets(client, assetIds, force, !dryRun && confirm);
+
     [McpServerTool(Name = "immich_assets_delete")]
     [Description("Delete asset(s). Requires explicit confirmation.")]
-    public static async Task<string> Delete(
+    public static async Task<string> DeleteAssets(
         ImmichClient client,
         [Description("Asset IDs (comma-separated UUIDs)")] string assetIds,
         [Description("Force delete (bypass trash)")] bool force = false,

--- a/ImmichMCP/Tools/AssetTools.cs
+++ b/ImmichMCP/Tools/AssetTools.cs
@@ -624,19 +624,20 @@ public static class AssetTools
     [Obsolete("Use DeleteAssets instead.")]
     public static Task<string> Delete(
         ImmichClient client,
-        [Description("Asset IDs (comma-separated UUIDs)")] string assetIds,
-        [Description("Force delete (bypass trash)")] bool force = false,
-        [Description("Dry run mode - shows what would be deleted without applying")] bool dryRun = true,
-        [Description("Must be true to confirm deletion")] bool confirm = false)
-        => DeleteAssets(client, assetIds, force, !dryRun && confirm);
+        string assetIds,
+        bool force = false,
+        bool dryRun = true,
+        bool confirm = false)
+        => DeleteAssets(client, assetIds, force, confirm, dryRun);
 
     [McpServerTool(Name = "immich_assets_delete")]
-    [Description("Delete asset(s). Requires explicit confirmation.")]
+    [Description("Delete asset(s). Returns a preview unless confirm=true.")]
     public static async Task<string> DeleteAssets(
         ImmichClient client,
         [Description("Asset IDs (comma-separated UUIDs)")] string assetIds,
         [Description("Force delete (bypass trash)")] bool force = false,
-        [Description("Must be true to confirm deletion")] bool confirm = false)
+        [Description("Must be true to confirm deletion")] bool confirm = false,
+        [Description("Deprecated - omit. When true, forces a preview even if confirm=true.")] bool? dryRun = null)
     {
         var ids = ParseStringArray(assetIds);
 
@@ -650,7 +651,9 @@ public static class AssetTools
             return JsonSerializer.Serialize(errorResponse);
         }
 
-        if (!confirm)
+        // dryRun is retained, deprecated, only so callers written against the old
+        // two-switch contract keep getting a preview instead of a surprise deletion.
+        if (!confirm || dryRun == true)
         {
             // Get asset info for dry run
             var assetInfos = new List<object>();


### PR DESCRIPTION
## Summary

- remove the redundant `dryRun` argument from `immich_assets_delete`
- use `confirm=false` for the existing deletion preview and `confirm=true` to execute
- keep `force` separate because it selects trash versus permanent deletion

## Root cause

Asset deletion required both `dryRun=false` and `confirm=true`, while its tool description said only that explicit confirmation was required. A caller supplying `confirm=true` therefore still received a dry-run response. Other destructive tools in ImmichMCP already use `confirm` alone.

## Impact

The MCP contract now has one unambiguous safety switch: omitted or false confirmation returns the existing preview, and true confirmation performs the requested deletion.

## Validation

- `dotnet test ImmichMCP.Tests/ImmichMCP.Tests.csproj` (91 passed, 10 live-integration tests skipped)
