### PR TITLE
Centralize page-size clamping and ID-list validation in ParsingHelpers

### DIFF
--- a/ImmichMCP.Tests/Tools/SearchToolsTests.cs
+++ b/ImmichMCP.Tests/Tools/SearchToolsTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text.Json;
 using FluentAssertions;
 using RichardSzalay.MockHttp;
 using ImmichMCP.Tools;
@@ -116,5 +117,78 @@ public class SearchToolsTests
 
         // Assert
         result.Should().Contain("OCR search text is required");
+    }
+
+    [Fact]
+    public async Task MetadataSearch_ClampsSizeAndReflectsClampedValue_InMeta()
+    {
+        // Arrange
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        var searchResult = new
+        {
+            assets = new
+            {
+                total = 0,
+                count = 0,
+                items = Array.Empty<object>(),
+                nextPage = (string?)null
+            }
+        };
+
+        string? capturedRequestBody = null;
+        handler.When(HttpMethod.Post, "*/search/metadata")
+            .With(req =>
+            {
+                capturedRequestBody = req.Content!.ReadAsStringAsync().Result;
+                return true;
+            })
+            .Respond("application/json", TestFixtures.ToJson(searchResult));
+
+        // Act
+        var result = await SearchTools.MetadataSearch(client, size: 0);
+
+        // Assert: the size sent upstream and the size echoed in meta must agree,
+        // otherwise callers doing pagination math see a page_size that doesn't match what was requested.
+        capturedRequestBody.Should().Contain("\"size\":1");
+
+        using var json = JsonDocument.Parse(result);
+        var meta = json.RootElement.GetProperty("meta");
+        meta.GetProperty("page_size").GetInt32().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SmartSearch_ClampsSizeAndReflectsClampedValue_InMeta()
+    {
+        // Arrange
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        var searchResult = new
+        {
+            assets = new
+            {
+                total = 0,
+                count = 0,
+                items = Array.Empty<object>(),
+                nextPage = (string?)null
+            }
+        };
+
+        string? capturedRequestBody = null;
+        handler.When(HttpMethod.Post, "*/search/smart")
+            .With(req =>
+            {
+                capturedRequestBody = req.Content!.ReadAsStringAsync().Result;
+                return true;
+            })
+            .Respond("application/json", TestFixtures.ToJson(searchResult));
+
+        // Act
+        var result = await SearchTools.SmartSearch(client, query: "sunset", size: 100000);
+
+        // Assert
+        capturedRequestBody.Should().Contain("\"size\":100");
+
+        using var json = JsonDocument.Parse(result);
+        var meta = json.RootElement.GetProperty("meta");
+        meta.GetProperty("page_size").GetInt32().Should().Be(100);
     }
 }

--- a/ImmichMCP.Tests/Utils/ParsingHelpersTests.cs
+++ b/ImmichMCP.Tests/Utils/ParsingHelpersTests.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+using FluentAssertions;
+using ImmichMCP.Models.Common;
+using static ImmichMCP.Utils.ParsingHelpers;
+
+namespace ImmichMCP.Tests.Utils;
+
+public class ParsingHelpersTests
+{
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(-5, 1)]
+    [InlineData(1, 1)]
+    [InlineData(50, 50)]
+    [InlineData(100, 100)]
+    [InlineData(101, 100)]
+    [InlineData(int.MaxValue, 100)]
+    public void ClampPageSize_ClampsToRange(int requested, int expected)
+    {
+        ClampPageSize(requested, 100).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(",,")]
+    public void RequireIds_ReturnsValidationError_WhenNoIdsPresent(string? csv)
+    {
+        var error = RequireIds(csv, "https://immich.example", "asset IDs", out var ids);
+
+        error.Should().NotBeNull();
+        ids.Should().BeEmpty();
+
+        using var json = JsonDocument.Parse(error!);
+        json.RootElement.GetProperty("ok").GetBoolean().Should().BeFalse();
+        json.RootElement.GetProperty("error").GetProperty("code").GetString().Should().Be(ErrorCodes.Validation);
+        json.RootElement.GetProperty("error").GetProperty("message").GetString().Should().Be("No valid asset IDs provided");
+    }
+
+    [Fact]
+    public void RequireIds_ReturnsNullAndPopulatesIds_WhenIdsPresent()
+    {
+        var error = RequireIds(" id1 , id2 ,,id3 ", "https://immich.example", "asset IDs", out var ids);
+
+        error.Should().BeNull();
+        ids.Should().Equal("id1", "id2", "id3");
+    }
+}

--- a/ImmichMCP/Tools/AlbumTools.cs
+++ b/ImmichMCP/Tools/AlbumTools.cs
@@ -154,16 +154,9 @@ public static class AlbumTools
         [Description("Album ID (UUID)")] string albumId,
         [Description("Asset IDs to add (comma-separated UUIDs)")] string assetIds)
     {
-        var ids = ParseStringArray(assetIds);
-
-        if (ids == null || ids.Length == 0)
+        if (RequireIds(assetIds, client.BaseUrl, "asset IDs", out var ids) is { } idsError)
         {
-            var errorResponse = McpErrorResponse.Create(
-                ErrorCodes.Validation,
-                "No valid asset IDs provided",
-                meta: new McpMeta { ImmichBaseUrl = client.BaseUrl }
-            );
-            return JsonSerializer.Serialize(errorResponse);
+            return idsError;
         }
 
         var result = await client.AddAssetsToAlbumAsync(albumId, ids).ConfigureAwait(false);
@@ -201,16 +194,9 @@ public static class AlbumTools
         [Description("Album ID (UUID)")] string albumId,
         [Description("Asset IDs to remove (comma-separated UUIDs)")] string assetIds)
     {
-        var ids = ParseStringArray(assetIds);
-
-        if (ids == null || ids.Length == 0)
+        if (RequireIds(assetIds, client.BaseUrl, "asset IDs", out var ids) is { } idsError)
         {
-            var errorResponse = McpErrorResponse.Create(
-                ErrorCodes.Validation,
-                "No valid asset IDs provided",
-                meta: new McpMeta { ImmichBaseUrl = client.BaseUrl }
-            );
-            return JsonSerializer.Serialize(errorResponse);
+            return idsError;
         }
 
         var result = await client.RemoveAssetsFromAlbumAsync(albumId, ids).ConfigureAwait(false);

--- a/ImmichMCP/Tools/AssetTools.cs
+++ b/ImmichMCP/Tools/AssetTools.cs
@@ -126,7 +126,7 @@ public static class AssetTools
         [Description("Filter by assets updated before this date (ISO format)")] string? updatedBefore = null)
     {
         var assets = await client.GetAssetsAsync(
-            size: Math.Min(size, 1000),
+            size: ClampPageSize(size, 1000),
             isFavorite: isFavorite,
             isArchived: isArchived,
             isTrashed: isTrashed,
@@ -557,16 +557,9 @@ public static class AssetTools
         [Description("Dry run mode - shows what would change without applying")] bool dryRun = true,
         [Description("Must be true to execute the operation")] bool confirm = false)
     {
-        var ids = ParseStringArray(assetIds);
-
-        if (ids == null || ids.Length == 0)
+        if (RequireIds(assetIds, client.BaseUrl, "asset IDs", out var ids) is { } idsError)
         {
-            var errorResponse = McpErrorResponse.Create(
-                ErrorCodes.Validation,
-                "No valid asset IDs provided",
-                meta: new McpMeta { ImmichBaseUrl = client.BaseUrl }
-            );
-            return JsonSerializer.Serialize(errorResponse);
+            return idsError;
         }
 
         if (dryRun || !confirm)
@@ -630,16 +623,9 @@ public static class AssetTools
         [Description("Dry run mode - shows what would be deleted without applying")] bool dryRun = true,
         [Description("Must be true to confirm deletion")] bool confirm = false)
     {
-        var ids = ParseStringArray(assetIds);
-
-        if (ids == null || ids.Length == 0)
+        if (RequireIds(assetIds, client.BaseUrl, "asset IDs", out var ids) is { } idsError)
         {
-            var errorResponse = McpErrorResponse.Create(
-                ErrorCodes.Validation,
-                "No valid asset IDs provided",
-                meta: new McpMeta { ImmichBaseUrl = client.BaseUrl }
-            );
-            return JsonSerializer.Serialize(errorResponse);
+            return idsError;
         }
 
         if (dryRun || !confirm)

--- a/ImmichMCP/Tools/PeopleTools.cs
+++ b/ImmichMCP/Tools/PeopleTools.cs
@@ -23,7 +23,7 @@ public static class PeopleTools
         [Description("Page number (default: 1)")] int page = 1,
         [Description("Page size (default: 25, max: 100)")] int size = 25)
     {
-        size = Math.Min(Math.Max(size, 1), 100);
+        size = ClampPageSize(size, 100);
         page = Math.Max(page, 1);
 
         var result = await client.GetPeopleAsync(withHidden, page, size).ConfigureAwait(false);
@@ -138,16 +138,9 @@ public static class PeopleTools
         [Description("Source person IDs to merge from (comma-separated UUIDs)")] string sourceIds,
         [Description("Must be true to confirm merge")] bool confirm = false)
     {
-        var ids = ParseStringArray(sourceIds);
-
-        if (ids == null || ids.Length == 0)
+        if (RequireIds(sourceIds, client.BaseUrl, "source person IDs", out var ids) is { } idsError)
         {
-            var errorResponse = McpErrorResponse.Create(
-                ErrorCodes.Validation,
-                "No valid source person IDs provided",
-                meta: new McpMeta { ImmichBaseUrl = client.BaseUrl }
-            );
-            return JsonSerializer.Serialize(errorResponse);
+            return idsError;
         }
 
         if (!confirm)
@@ -210,7 +203,7 @@ public static class PeopleTools
         [Description("Page number (default: 1)")] int page = 1,
         [Description("Page size (default: 25, max: 100)")] int size = 25)
     {
-        size = Math.Min(Math.Max(size, 1), 100);
+        size = ClampPageSize(size, 100);
         page = Math.Max(page, 1);
 
         var result = await client.SearchPersonAssetsAsync(personId, page, size).ConfigureAwait(false);

--- a/ImmichMCP/Tools/SearchTools.cs
+++ b/ImmichMCP/Tools/SearchTools.cs
@@ -37,10 +37,12 @@ public static class SearchTools
         [Description("Filter by original file name (partial match)")] string? originalFileName = null,
         [Description("Sort order: asc or desc")] string? order = null)
     {
+        size = ClampPageSize(size, 100);
+
         var request = new MetadataSearchRequest
         {
             Page = page,
-            Size = Math.Min(size, 100),
+            Size = size,
             Type = type?.ToUpperInvariant(),
             IsFavorite = isFavorite,
             Visibility = VisibilityFromArchived(isArchived),
@@ -107,11 +109,13 @@ public static class SearchTools
             return JsonSerializer.Serialize(errorResponse);
         }
 
+        size = ClampPageSize(size, 100);
+
         var request = new SmartSearchRequest
         {
             Query = query,
             Page = page,
-            Size = Math.Min(size, 100),
+            Size = size,
             Type = type?.ToUpperInvariant(),
             IsFavorite = isFavorite,
             Visibility = VisibilityFromArchived(isArchived),
@@ -172,11 +176,13 @@ public static class SearchTools
             return JsonSerializer.Serialize(errorResponse);
         }
 
+        size = ClampPageSize(size, 100);
+
         var request = new MetadataSearchRequest
         {
             Ocr = text,
             Page = page,
-            Size = Math.Min(size, 100),
+            Size = size,
             Type = type?.ToUpperInvariant(),
             IsFavorite = isFavorite,
             Visibility = VisibilityFromArchived(isArchived),

--- a/ImmichMCP/Tools/TagTools.cs
+++ b/ImmichMCP/Tools/TagTools.cs
@@ -192,16 +192,9 @@ public static class TagTools
         [Description("Tag ID (UUID)")] string tagId,
         [Description("Asset IDs to tag (comma-separated UUIDs)")] string assetIds)
     {
-        var ids = ParseStringArray(assetIds);
-
-        if (ids == null || ids.Length == 0)
+        if (RequireIds(assetIds, client.BaseUrl, "asset IDs", out var ids) is { } idsError)
         {
-            var errorResponse = McpErrorResponse.Create(
-                ErrorCodes.Validation,
-                "No valid asset IDs provided",
-                meta: new McpMeta { ImmichBaseUrl = client.BaseUrl }
-            );
-            return JsonSerializer.Serialize(errorResponse);
+            return idsError;
         }
 
         var result = await client.TagAssetsAsync(tagId, ids).ConfigureAwait(false);
@@ -239,16 +232,9 @@ public static class TagTools
         [Description("Tag ID (UUID)")] string tagId,
         [Description("Asset IDs to untag (comma-separated UUIDs)")] string assetIds)
     {
-        var ids = ParseStringArray(assetIds);
-
-        if (ids == null || ids.Length == 0)
+        if (RequireIds(assetIds, client.BaseUrl, "asset IDs", out var ids) is { } idsError)
         {
-            var errorResponse = McpErrorResponse.Create(
-                ErrorCodes.Validation,
-                "No valid asset IDs provided",
-                meta: new McpMeta { ImmichBaseUrl = client.BaseUrl }
-            );
-            return JsonSerializer.Serialize(errorResponse);
+            return idsError;
         }
 
         var result = await client.UntagAssetsAsync(tagId, ids).ConfigureAwait(false);

--- a/ImmichMCP/Utils/ParsingHelpers.cs
+++ b/ImmichMCP/Utils/ParsingHelpers.cs
@@ -1,3 +1,5 @@
+using ImmichMCP.Models.Common;
+
 namespace ImmichMCP.Utils;
 
 /// <summary>
@@ -16,6 +18,33 @@ public static class ParsingHelpers
             return null;
 
         return input.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    /// <summary>
+    /// Clamps a requested page size to at least 1 and at most <paramref name="max"/>.
+    /// </summary>
+    public static int ClampPageSize(int requested, int max) => Math.Clamp(requested, 1, max);
+
+    /// <summary>
+    /// Parses a comma-separated ID list and returns a ready-to-serialize validation error
+    /// string when empty; returns null (with <paramref name="ids"/> populated) otherwise.
+    /// </summary>
+    /// <param name="csv">Comma-separated ID list (e.g., "id1,id2,id3")</param>
+    /// <param name="baseUrl">Immich base URL to include in the error response's meta</param>
+    /// <param name="entityLabel">Label describing the missing IDs, e.g. "asset IDs" or "source person IDs"</param>
+    /// <param name="ids">Populated with the parsed IDs (empty array if none)</param>
+    /// <returns>A serialized <see cref="McpErrorResponse"/> when <paramref name="ids"/> is empty; otherwise null</returns>
+    public static string? RequireIds(string? csv, string baseUrl, string entityLabel, out string[] ids)
+    {
+        ids = ParseStringArray(csv) ?? [];
+        if (ids.Length > 0)
+            return null;
+
+        var errorResponse = McpErrorResponse.Create(
+            ErrorCodes.Validation,
+            $"No valid {entityLabel} provided",
+            meta: new McpMeta { ImmichBaseUrl = baseUrl });
+        return System.Text.Json.JsonSerializer.Serialize(errorResponse);
     }
 
     /// <summary>


### PR DESCRIPTION
Centralize tool validation                                                                                          
                                                                                                                    
- Moved page-size clamping and ID-list validation into shared helpers instead of duplicating the logic in each tool
- Fixed a bug where search tools could report a different page size than what was actually used
- Added tests for the new shared validation logic