### PR TITLE
Add `/health/ready` endpoint that checks Immich connectivity

### DIFF
--- a/ImmichMCP.Tests/Client/ReadinessCacheTests.cs
+++ b/ImmichMCP.Tests/Client/ReadinessCacheTests.cs
@@ -1,0 +1,109 @@
+using System.Net;
+using FluentAssertions;
+using RichardSzalay.MockHttp;
+using ImmichMCP.Tests.Fixtures;
+
+namespace ImmichMCP.Tests.Client;
+
+/// <summary>
+/// Exercises the internal readiness cache used by the <c>/health/ready</c> endpoint
+/// in <c>Program.cs</c>. It is visible here via <c>InternalsVisibleTo</c>.
+/// </summary>
+public class ReadinessCacheTests
+{
+    [Fact]
+    public async Task GetOrRefreshAsync_ReturnsReady_WhenPingSucceeds()
+    {
+        // Arrange
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        var serverInfo = new { version = "1.99.0" };
+
+        handler.When(HttpMethod.Get, "*/server/about")
+            .Respond("application/json", TestFixtures.ToJson(serverInfo));
+
+        var cache = new ReadinessCache();
+
+        // Act
+        var (success, version, error) = await cache.GetOrRefreshAsync(client, CancellationToken.None);
+
+        // Assert
+        success.Should().BeTrue();
+        version.Should().Be("1.99.0");
+        error.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetOrRefreshAsync_ReturnsNotReady_WhenPingFails()
+    {
+        // Arrange
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+
+        handler.When(HttpMethod.Get, "*/server/about")
+            .Respond(HttpStatusCode.ServiceUnavailable);
+
+        var cache = new ReadinessCache();
+
+        // Act
+        var (success, version, error) = await cache.GetOrRefreshAsync(client, CancellationToken.None);
+
+        // Assert
+        success.Should().BeFalse();
+        version.Should().BeNull();
+        error.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task GetOrRefreshAsync_ReturnsCachedResult_WithoutRepingingWithinCacheWindow()
+    {
+        // Arrange
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        var serverInfo = new { version = "1.99.0" };
+
+        var mockedRequest = handler.When(HttpMethod.Get, "*/server/about")
+            .Respond("application/json", TestFixtures.ToJson(serverInfo));
+
+        var cache = new ReadinessCache();
+
+        // Act: call twice in quick succession (well within the 10s cache window)
+        var first = await cache.GetOrRefreshAsync(client, CancellationToken.None);
+        var second = await cache.GetOrRefreshAsync(client, CancellationToken.None);
+
+        // Assert: only the first call actually reached Immich
+        first.Success.Should().BeTrue();
+        second.Should().Be(first);
+        handler.GetMatchCount(mockedRequest).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetOrRefreshAsync_SharesInFlightRefresh_AcrossConcurrentCallers()
+    {
+        // Arrange: hold the upstream response open so several callers overlap a single refresh.
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        var serverInfo = new { version = "1.99.0" };
+        var release = new TaskCompletionSource();
+
+        var mockedRequest = handler.When(HttpMethod.Get, "*/server/about")
+            .Respond(async (HttpRequestMessage _) =>
+            {
+                await release.Task;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(TestFixtures.ToJson(serverInfo), System.Text.Encoding.UTF8, "application/json")
+                };
+            });
+
+        var cache = new ReadinessCache();
+
+        // Act: start several concurrent callers before the single upstream ping completes
+        var calls = Enumerable.Range(0, 5)
+            .Select(_ => cache.GetOrRefreshAsync(client, CancellationToken.None))
+            .ToArray();
+
+        release.SetResult();
+        var results = await Task.WhenAll(calls);
+
+        // Assert: exactly one upstream ping was issued, and every caller got the same result
+        handler.GetMatchCount(mockedRequest).Should().Be(1);
+        results.Should().OnlyContain(r => r.Success && r.Version == "1.99.0");
+    }
+}

--- a/ImmichMCP/Client/ImmichClient.cs
+++ b/ImmichMCP/Client/ImmichClient.cs
@@ -65,6 +65,12 @@ public class ImmichClient
 
             return (false, null, $"HTTP {(int)response.StatusCode}: {response.ReasonPhrase}");
         }
+        catch (OperationCanceledException)
+        {
+            // Let cancellation (caller abort or timeout) propagate; callers distinguish the two
+            // via their own token rather than have it folded into a generic failure result here.
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to ping Immich API");

--- a/ImmichMCP/Program.cs
+++ b/ImmichMCP/Program.cs
@@ -155,8 +155,20 @@ else
         }
     }).DisableAntiforgery();
 
-    // Health check endpoint
+    // Health check endpoint (liveness only: is the process up, no upstream dependency)
     app.MapGet("/health", () => Results.Ok(new { status = "healthy", timestamp = DateTime.UtcNow }));
+
+    // Readiness endpoint: verifies the process can actually reach Immich.
+    // Results are cached for a short window so frequent probe ticks don't hammer Immich.
+    var readinessCache = new ReadinessCache();
+    app.MapGet("/health/ready", async (ImmichClient immichClient, CancellationToken cancellationToken) =>
+    {
+        var (success, version, error) = await readinessCache.GetOrRefreshAsync(immichClient, cancellationToken).ConfigureAwait(false);
+
+        return success
+            ? Results.Ok(new { status = "ready", immich_connected = true, version })
+            : Results.Json(new { status = "not_ready", immich_connected = false, error }, statusCode: StatusCodes.Status503ServiceUnavailable);
+    });
 
     app.Logger.LogInformation("ImmichMCP server starting on port {Port}", port);
     app.Logger.LogInformation("MCP endpoint available at: http://localhost:{Port}/mcp", port);
@@ -250,5 +262,71 @@ static class McpServerBuilderToolModeExtensions
         return useToolGateway
             ? builder.WithImmichToolGateway()
             : builder.WithToolsFromAssembly();
+    }
+}
+
+/// <summary>
+/// Caches the result of the last real Immich connectivity check so that frequent
+/// readiness probes (e.g. Kubernetes hitting <c>/health/ready</c> every few seconds)
+/// don't each translate into a live call to Immich. A new ping is only issued once
+/// <see cref="CacheDurationSeconds"/> have elapsed since the previous one; callers that
+/// arrive within the cache window get the last known result immediately, and callers
+/// that arrive while a refresh is already running share that same refresh instead of
+/// each starting their own.
+/// </summary>
+sealed class ReadinessCache
+{
+    private const int CacheDurationSeconds = 10;
+    private const int PingTimeoutSeconds = 5;
+
+    private readonly Lock _gate = new();
+    private DateTime _lastCheckedUtc = DateTime.MinValue;
+    private (bool Success, string? Version, string? Error) _lastResult = (false, null, "Not checked yet");
+    private Task<(bool Success, string? Version, string? Error)>? _refreshInFlight;
+
+    public Task<(bool Success, string? Version, string? Error)> GetOrRefreshAsync(ImmichClient client, CancellationToken cancellationToken)
+    {
+        Task<(bool Success, string? Version, string? Error)> refresh;
+        lock (_gate)
+        {
+            if (DateTime.UtcNow - _lastCheckedUtc < TimeSpan.FromSeconds(CacheDurationSeconds))
+            {
+                return Task.FromResult(_lastResult);
+            }
+
+            refresh = _refreshInFlight ??= RefreshAsync(client);
+        }
+
+        // WaitAsync only stops this caller from waiting on cancellation; it never cancels the
+        // shared refresh itself, so a caller aborting (e.g. a probe timing out) can't poison the
+        // cache with a result other callers are still legitimately waiting on.
+        return refresh.WaitAsync(cancellationToken);
+    }
+
+    private async Task<(bool Success, string? Version, string? Error)> RefreshAsync(ImmichClient client)
+    {
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(PingTimeoutSeconds));
+
+        (bool Success, string? Version, string? Error) result;
+        try
+        {
+            var (success, info, error) = await client.PingAsync(timeoutCts.Token).ConfigureAwait(false);
+            result = success
+                ? (true, info?.Version, null)
+                : (false, null, error ?? "Ping failed");
+        }
+        catch (OperationCanceledException)
+        {
+            result = (false, null, "Timed out waiting for Immich to respond");
+        }
+
+        lock (_gate)
+        {
+            _lastCheckedUtc = DateTime.UtcNow;
+            _lastResult = result;
+            _refreshInFlight = null;
+        }
+
+        return result;
     }
 }

--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ ImmichMCP is published as a container image at `ghcr.io/barryw/immichmcp`. Run i
 host containers — Docker, Docker Compose, or Kubernetes.
 
 - Set `IMMICH_BASE_URL` and `IMMICH_API_KEY` (see [Environment Variables](#environment-variables)).
-- Expose the HTTP port (default `5000`). The MCP endpoint is served at `/mcp` and a health check
-  at `/health`.
+- Expose the HTTP port (default `5000`). The MCP endpoint is served at `/mcp`. Two health
+  endpoints are available: `/health` (liveness, use for restarts) and `/health/ready`
+  (readiness, pings Immich and returns `503` if unreachable, use for traffic routing).
 - For remote/HTTP clients, set `IMMICH_TOOL_MODE=gateway` so clients enable tool categories on
   demand instead of loading all tools up front.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,9 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     healthcheck:
+      # Liveness-style check: only confirms the process is up. Compose has no separate
+      # readiness concept, but /health/ready is also available if you want a stricter
+      # check that verifies connectivity to Immich (e.g. by swapping the path below).
       test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
       interval: 30s
       timeout: 10s

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -46,7 +46,10 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 30
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              path: /health/ready
               port: 5000
             initialDelaySeconds: 5
             periodSeconds: 10
+            timeoutSeconds: 6
+            failureThreshold: 3


### PR DESCRIPTION
- Splits liveness (/health, process-up only) from readiness (/health/ready, pings Immich via ImmichClient.PingAsync with a 5s timeout and a 10s in-process result cache to avoid hammering Immich on frequent probes).
- Updates k8s readinessProbe to use the new endpoint, leaves livenessProbe untouched, documents the split in README, and notes the option in docker-compose. Adds unit tests for the new ReadinessCache.