### PR TITLE
Add Dependabot config and NuGet vulnerability audit workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -40,7 +40,10 @@ jobs:
             echo "::error::dotnet list package did not complete cleanly (exit $STATUS); treating as a failed audit"
             exit 1
           fi
-          if echo "$OUTPUT" | grep -qi "vulnerable packages"; then
+          # Match the phrasing used only when vulnerabilities are present. A clean run
+          # prints "has no vulnerable packages given the current sources", so a looser
+          # match on "vulnerable packages" reports a finding on every green build.
+          if echo "$OUTPUT" | grep -q "has the following vulnerable packages"; then
             echo "::error::Vulnerable NuGet packages detected"
             exit 1
           fi

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,46 @@
+name: Dependency Vulnerability Audit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    # Every Monday at 06:00 UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Check for vulnerable packages
+        env:
+          DOTNET_CLI_UI_LANGUAGE: en
+        run: |
+          set +e
+          OUTPUT=$(dotnet list package --vulnerable --include-transitive 2>&1)
+          STATUS=$?
+          set -e
+          echo "$OUTPUT"
+          if [ "$STATUS" -ne 0 ]; then
+            echo "::error::dotnet list package did not complete cleanly (exit $STATUS); treating as a failed audit"
+            exit 1
+          fi
+          if echo "$OUTPUT" | grep -qi "vulnerable packages"; then
+            echo "::error::Vulnerable NuGet packages detected"
+            exit 1
+          fi


### PR DESCRIPTION
### Add dependency vulnerability scanning                                                               
                                                                                                    
- Dependabot config for nuget/github-actions/docker, weekly updates, capped at 10 open nuget PRs    
- CI workflow audits NuGet packages for known vulnerabilities on PRs, push to main, and weekly cron
- Fails closed if the audit command errors instead of silently passing
- Actions pinned to commit SHA