### PR TITLE
fix(ci): make release steps restartable after a failed run

### DIFF
--- a/.woodpecker/release.yml
+++ b/.woodpecker/release.yml
@@ -243,14 +243,25 @@ steps:
         git config user.name "Woodpecker CI"
         git remote set-url origin "https://x-access-token:$GITHUB_TOKEN@github.com/barryw/ImmichMCP.git"
 
-        # Commit version.json update
+        # Commit version.json update. On a restart main already carries the bump,
+        # so pushing this pipeline's older HEAD would be a non-fast-forward.
         git add version.json
-        git diff --staged --quiet || git commit -m "chore(release): bump version to $VERSION [skip ci]"
-        git push origin HEAD:main
+        if git diff --staged --quiet; then
+          echo "version.json already at $VERSION; nothing to commit"
+        else
+          git commit -m "chore(release): bump version to $VERSION [skip ci]"
+          git push origin HEAD:main
+        fi
 
-        # Create and push tag
-        git tag -a "$TAG" -m "Release $VERSION"
-        git push origin "$TAG"
+        # Create and push tag. Restarting a run that already tagged must not abort
+        # the pipeline before the deploy and verification steps get to run again.
+        if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null ||
+           git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
+          echo "Tag $TAG already exists; skipping tag creation"
+        else
+          git tag -a "$TAG" -m "Release $VERSION"
+          git push origin "$TAG"
+        fi
     depends_on: [package, docker]
 
   # Create GitHub release
@@ -272,6 +283,16 @@ steps:
         TAG=$(cat .tag)
         VERSION=$(cat .version)
         LATEST_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "v0.0.0")
+
+        # POSTing a release for a tag that already has one returns 422 and would
+        # fail the run, so a restart must treat an existing release as done.
+        if curl -fsS \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github.v3+json" \
+          "https://api.github.com/repos/barryw/ImmichMCP/releases/tags/$TAG" >/dev/null 2>&1; then
+          echo "Release $TAG already exists; skipping"
+          exit 0
+        fi
 
         echo "Creating GitHub release for $TAG"
 


### PR DESCRIPTION
Main has been red since [pipeline 71](https://ci.barrywalker.io/repos/4/pipeline/71/1) (v3.2.1). The step that failed, `verify-gitops-deploy`, failed for an unrelated reason — an in-cluster TLS hairpin, since fixed in `barryw/infrastructure` #145 and #146. The pod is healthy and both gateway integration tests pass against it today.

The problem is that the red run cannot be cleared, and that is a real defect in the pipeline rather than a cosmetic one.

## Why the build is stuck

`calculate-version` derives the version from the last tag, so a restart of pipeline 71 recomputes `v3.2.1` — a tag that now exists. `git-tag` then runs:

```sh
git tag -a "$TAG" -m "Release $VERSION"
```

which aborts with `fatal: tag v3.2.1 already exists`. The restart therefore dies *earlier* than the original run, and `update-gitops` and `verify-gitops-deploy` never execute at all.

Re-running at the current `main` is no better: `v3.2.1` points at `30a5a1d`, which is `main` HEAD, so there are no commits since the tag, `BUMP=none`, and every step from `git-tag` onward exits 0 early. That is a green badge that skipped the step that was failing — worse than red.

So any release that fails after tagging permanently poisons the branch. This one is just the first to hit it.

## Fix

Three guards in `.woodpecker/release.yml`, each making a step idempotent:

| Step | Failure on restart | Guard |
|---|---|---|
| `git-tag` (version.json) | `git push origin HEAD:main` is a non-fast-forward once main carries the bump | only commit and push when `version.json` actually changed |
| `git-tag` (tag) | `git tag -a` aborts, tag exists | skip when the tag exists locally **or** on the remote |
| `release` | duplicate release POST returns 422, `curl -fsS` fails the step | skip when a release already exists for the tag |

`update-gitops` was already idempotent — it exits early when the manifest points at the image, and reuses an open deploy PR — so it needed nothing.

## Verification

Guards exercised in a scratch repo with a real remote, three runs:

```
RUN 1 (fresh v3.2.2):        committed+pushed 3.2.2 / created v3.2.2
RUN 2 (restart, same ver):   nothing to commit     / tag exists, skipping
RUN 3 (tag remote-only):     nothing to commit     / tag exists, skipping
EXIT=0
```

RUN 3 deletes the local tag first, which is the case that matters — CI clones fresh, so `git ls-remote` is the check that actually fires.

The release guard was tested against the live API: `v3.2.1` → found, skips; `v9.9.9` → not found, proceeds.

`.woodpecker/release.yml` parses, all nine steps intact. Full test suite on this branch: 94 passed, 0 failed, 10 skipped.

## Effect

This commit is a conventional `fix`, so merging it bumps to 3.2.2 and runs the release pipeline end to end — `update-gitops` and `verify-gitops-deploy` included — against the now-healthy cluster. That produces an honest green rather than a skipped one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)