### PR TITLE
fix(ci): make commitlint actually check commits

### DIFF
--- a/.woodpecker/pr.yml
+++ b/.woodpecker/pr.yml
@@ -26,9 +26,16 @@ steps:
       - |
         set -eu
 
-        git rev-parse --verify origin/main >/dev/null 2>&1 || git fetch -q origin main
+        # The clone is shallow, so origin/main and HEAD can end up with no reachable
+        # common ancestor. merge-base then exits non-zero printing nothing, which under
+        # set -e kills this step with no explanation. Deepen first, same as release.yml.
+        git fetch -q --unshallow origin main 2>/dev/null || git fetch -q origin main
 
-        BASE=$(git merge-base origin/main HEAD)
+        if ! BASE=$(git merge-base origin/main HEAD 2>/dev/null); then
+          echo "Could not determine a merge base between origin/main and HEAD"
+          exit 1
+        fi
+
         git log --format=%s "$BASE"..HEAD > /tmp/commit-subjects
 
         COUNT=$(wc -l < /tmp/commit-subjects | tr -d ' ')

--- a/.woodpecker/pr.yml
+++ b/.woodpecker/pr.yml
@@ -17,16 +17,42 @@ steps:
   - name: commitlint
     image: node:22-alpine
     commands:
+      # node:22-alpine ships without git. Without this the git log below fails, the
+      # loop reads nothing, and the step reports success having checked nothing.
+      - apk add --no-cache git
       - npm install -g @commitlint/cli @commitlint/config-conventional
       - |
         echo "module.exports = { extends: ['@commitlint/config-conventional'] };" > commitlint.config.js
       - |
-        # Check all commits in the PR
-        git log --format=%s origin/main..HEAD | while read -r msg; do
+        set -eu
+
+        git rev-parse --verify origin/main >/dev/null 2>&1 || git fetch -q origin main
+
+        BASE=$(git merge-base origin/main HEAD)
+        git log --format=%s "$BASE"..HEAD > /tmp/commit-subjects
+
+        COUNT=$(wc -l < /tmp/commit-subjects | tr -d ' ')
+        if [ "$COUNT" -eq 0 ]; then
+          echo "No commits found between origin/main and HEAD; refusing to report success"
+          exit 1
+        fi
+
+        echo "Checking $COUNT commit subject(s)"
+
+        # Read from a file rather than a pipe so the failure flag survives the loop,
+        # and report every bad subject instead of stopping at the first.
+        FAILED=0
+        while IFS= read -r msg; do
           echo "Checking: $msg"
-          echo "$msg" | commitlint || exit 1
-        done
-      - echo "All commits follow conventional commit format"
+          echo "$msg" | commitlint || FAILED=1
+        done < /tmp/commit-subjects
+
+        if [ "$FAILED" -ne 0 ]; then
+          echo "One or more commit subjects are not conventional commits"
+          exit 1
+        fi
+
+        echo "All commits follow conventional commit format"
 
   - name: build-and-test
     image: mcr.microsoft.com/dotnet/sdk:10.0


### PR DESCRIPTION
The `commitlint` step has never checked a commit. From the real log of [pipeline 69](https://ci.barrywalker.io/repos/4/pipeline/69/1) (PR #20, subject `Simplify asset deletion confirmation` — which commitlint rejects):

```
+ # Check all commits in the PR
git log --format=%s origin/main..HEAD | while read -r msg; do
  echo "Checking: $msg"
  echo "$msg" | commitlint || exit 1
done
/bin/sh: git: not found
+ echo "All commits follow conventional commit format"
All commits follow conventional commit format
```

`node:22-alpine` ships without git. `git log` fails on the left of the pipe, the loop reads an empty stdin and never runs its body, the pipeline exits 0, and the step declares success. Every PR has passed it since it was added.

## Fix

- Install git.
- Resolve the range via `merge-base` and fetch `origin/main` if the shallow clone lacks it, so a missing ref cannot quietly produce an empty set.
- Fail when the range is empty instead of reporting success — "nothing to check" was exactly the silent-pass being fixed.
- Read subjects from a file rather than a pipe so the failure flag survives the loop, and report every bad subject instead of stopping at the first.

## Verification

Run in `node:22-alpine` against a real clone of this repo, capturing the step exit code:

| Branch subject | Exit |
|---|---|
| `fix: a properly conventional subject` | `0` — "All commits follow conventional commit format" |
| `Add unit coverage for stuff` | `1` — `subject may not be empty`, `type may not be empty` |

This PR is its own live test: its pipeline runs the new step against its own commit.

## Heads up on sequencing and strictness

This makes the check bite for the first time, and that has consequences worth deciding on before merging:

1. **Merge #25 first.** Its branch carries a non-conventional subject from the contributor, so once this lands that PR fails commitlint until the commit is reworded.
2. **This enforces conventional commits on every contributor commit.** Since everything here is squash-merged with a maintainer-written conventional subject, the merged history on `main` is already conventional regardless — which is what the release pipeline reads. So per-commit linting mostly affects drive-by contributions.

If the intent is only to protect the release pipeline, linting the squash subject rather than every commit would fit the workflow better. Happy to switch it — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)