### PR TITLE
fix(ci): lint the pull request title instead of every commit

### DIFF
--- a/.woodpecker/pr.yml
+++ b/.woodpecker/pr.yml
@@ -13,53 +13,39 @@ clone:
       depth: 50
 
 steps:
-  # Validate commit messages follow conventional commits
+  # Validate the pull request title, which is what lands on main.
   - name: commitlint
     image: node:22-alpine
     commands:
-      # node:22-alpine ships without git. Without this the git log below fails, the
-      # loop reads nothing, and the step reports success having checked nothing.
-      - apk add --no-cache git
       - npm install -g @commitlint/cli @commitlint/config-conventional
       - |
         echo "module.exports = { extends: ['@commitlint/config-conventional'] };" > commitlint.config.js
       - |
         set -eu
 
-        # The clone is shallow, so origin/main and HEAD can end up with no reachable
-        # common ancestor. merge-base then exits non-zero printing nothing, which under
-        # set -e kills this step with no explanation. Deepen first, same as release.yml.
-        git fetch -q --unshallow origin main 2>/dev/null || git fetch -q origin main
-
-        if ! BASE=$(git merge-base origin/main HEAD 2>/dev/null); then
-          echo "Could not determine a merge base between origin/main and HEAD"
+        # Pull requests here are squash-merged, so individual commits are discarded
+        # and the title becomes the subject on main. That subject is what
+        # release.yml later parses to decide the version bump, so it is the thing
+        # worth enforcing. Woodpecker sets CI_COMMIT_MESSAGE to the PR title on
+        # pull_request events.
+        TITLE="${CI_COMMIT_MESSAGE:-}"
+        if [ -z "$TITLE" ]; then
+          echo "CI_COMMIT_MESSAGE is empty; cannot determine the pull request title"
           exit 1
         fi
 
-        git log --format=%s "$BASE"..HEAD > /tmp/commit-subjects
+        SUBJECT=$(printf '%s\n' "$TITLE" | head -1)
+        echo "Checking pull request title: $SUBJECT"
 
-        COUNT=$(wc -l < /tmp/commit-subjects | tr -d ' ')
-        if [ "$COUNT" -eq 0 ]; then
-          echo "No commits found between origin/main and HEAD; refusing to report success"
+        if ! printf '%s\n' "$SUBJECT" | commitlint; then
+          echo
+          echo "The pull request title must be a conventional commit, for example:"
+          echo "  fix(tools): report the page size actually used"
+          echo "  feat(health): split liveness from readiness"
           exit 1
         fi
 
-        echo "Checking $COUNT commit subject(s)"
-
-        # Read from a file rather than a pipe so the failure flag survives the loop,
-        # and report every bad subject instead of stopping at the first.
-        FAILED=0
-        while IFS= read -r msg; do
-          echo "Checking: $msg"
-          echo "$msg" | commitlint || FAILED=1
-        done < /tmp/commit-subjects
-
-        if [ "$FAILED" -ne 0 ]; then
-          echo "One or more commit subjects are not conventional commits"
-          exit 1
-        fi
-
-        echo "All commits follow conventional commit format"
+        echo "Pull request title follows conventional commit format"
 
   - name: build-and-test
     image: mcr.microsoft.com/dotnet/sdk:10.0


### PR DESCRIPTION
Follow-up to #27, which made commitlint work for the first time. This changes *what* it checks.

## Why the target was wrong

Every PR here is squash-merged with a maintainer-written subject, so the individual commits in a branch are discarded. Linting them gated contributions on messages that never land, while the subject that *does* land — and that `release.yml` parses to decide the version bump — went unchecked.

Woodpecker sets `CI_COMMIT_MESSAGE` to the PR title on `pull_request` events, confirmed against pipeline 91:

```
event   = "pull_request"
title   = "fix(ci): make commitlint actually check commits"
message = "fix(ci): make commitlint actually check commits"
```

So the title is available and is the right thing to enforce. It is also GitHub's default squash subject.

## What changes

- Lints the PR title rather than the commit range.
- Fails loudly if `CI_COMMIT_MESSAGE` is empty rather than assuming a pass — the same silent-success trap #27 fixed.
- Prints an example of an acceptable title on failure.
- Drops the `apk add git`, the `--unshallow` fetch and the `merge-base` handling. None are needed once no range is computed, which also removes the shallow-clone failure mode that made #27 fail its first run.

## Verification

Run in `node:22-alpine`:

| `CI_COMMIT_MESSAGE` | Exit |
|---|---|
| `fix(tools): report the page size actually used` | `0` — title accepted |
| `Add unit coverage for Album/Tag/SharedLink/Upload tools` | `1` — `subject may not be empty`, `type may not be empty` |
| unset | `1` — "cannot determine the pull request title" |

This PR is its own live test: its title is what the new step lints.

## Note

Contributors now need a conventional PR *title* rather than conventional commits, which is a much lower bar and is visible and editable in the GitHub UI. #25 needs its title adjusted accordingly; I am doing that as part of landing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)