### PR TITLE
Add MCP Apps photo gallery support

### DIFF
--- a/ImmichMCP.Tests/Gateway/ImmichToolGatewayTests.cs
+++ b/ImmichMCP.Tests/Gateway/ImmichToolGatewayTests.cs
@@ -15,7 +15,7 @@ public class ImmichToolGatewayTests
         using var services = CreateServices();
         var registry = services.GetRequiredService<ImmichToolRegistry>();
 
-        registry.Tools.Should().HaveCount(49);
+        registry.Tools.Should().HaveCount(50);
         registry.Categories.Should().BeEquivalentTo(
             "activities",
             "albums",

--- a/ImmichMCP.Tests/Integration/ToolCoverageIntegrationTests.cs
+++ b/ImmichMCP.Tests/Integration/ToolCoverageIntegrationTests.cs
@@ -10,7 +10,7 @@ using ImmichMCP.Tools;
 namespace ImmichMCP.Tests.Integration;
 
 /// <summary>
-/// Exercises every one of the 49 MCP tools against a LIVE Immich instance.
+/// Exercises every one of the 50 MCP tools against a LIVE Immich instance.
 ///
 /// SAFETY CONTRACT (do not weaken): this test never creates, mutates, or deletes any
 /// pre-existing library data. Every mutation runs on throwaway fixtures created by the
@@ -36,6 +36,7 @@ public class ToolCoverageIntegrationTests
     {
         "immich_ping", "immich_capabilities",
         "immich_search_metadata", "immich_search_smart", "immich_search_ocr", "immich_search_explore",
+        "immich_assets_show",
         "immich_assets_statistics", "immich_assets_list", "immich_assets_get", "immich_assets_exif",
         "immich_assets_download_original", "immich_assets_download_thumbnail", "immich_assets_upload",
         "immich_assets_upload_from_path", "immich_assets_upload_init", "immich_assets_upload_status",
@@ -53,7 +54,7 @@ public class ToolCoverageIntegrationTests
     [MutationIntegrationFact]
     public async Task AllTools_ExercisedSafely_AgainstLiveImmich()
     {
-        AllToolNames.Should().HaveCount(49, "the fixed tool list must cover all 49 tools");
+        AllToolNames.Should().HaveCount(50, "the fixed tool list must cover all 50 tools");
 
         var settings = IntegrationTestSettings.Load();
         var client = settings.CreateClient();
@@ -244,6 +245,22 @@ public class ToolCoverageIntegrationTests
                 await Ok("immich_assets_exif", () => AssetTools.GetExif(client, asset1));
                 await Ok("immich_assets_download_original", async () => FirstText(await AssetTools.DownloadOriginal(client, asset1)));
                 await Ok("immich_assets_download_thumbnail", async () => FirstText(await AssetTools.DownloadThumbnail(client, asset1)));
+                try
+                {
+                    var gallery = await GalleryTools.ShowGallery(client, [asset1], "Integration test gallery");
+                    if (gallery.IsError == true || gallery.StructuredContent?.GetProperty("images").GetArrayLength() != 1)
+                    {
+                        Set("immich_assets_show", "FAIL", "gallery did not return the uploaded fixture preview");
+                    }
+                    else
+                    {
+                        Set("immich_assets_show", "PASS", null);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Set("immich_assets_show", "FAIL", Trunc(ex.Message));
+                }
                 await Ok("immich_assets_update", () => AssetTools.Update(client, asset1, isFavorite: true, description: "mcp tool test"));
                 await Ok("immich_assets_bulk_update", () => AssetTools.BulkUpdate(client, asset1, isFavorite: false, dryRun: false, confirm: true));
             }
@@ -352,6 +369,6 @@ public class ToolCoverageIntegrationTests
         var notPassing = status.Where(kv => kv.Value.Item1 != "PASS").Select(kv => kv.Key).ToList();
 
         notPassing.Should().BeEmpty(
-            $"every tool must PASS. {pass}/49 passed.\n{report}");
+            $"every tool must PASS. {pass}/50 passed.\n{report}");
     }
 }

--- a/ImmichMCP.Tests/Tools/GalleryToolsTests.cs
+++ b/ImmichMCP.Tests/Tools/GalleryToolsTests.cs
@@ -1,0 +1,81 @@
+using System.Net;
+using FluentAssertions;
+using ImmichMCP.Resources;
+using ImmichMCP.Tests.Fixtures;
+using ImmichMCP.Tools;
+using ModelContextProtocol.Protocol;
+using RichardSzalay.MockHttp;
+
+namespace ImmichMCP.Tests.Tools;
+
+public class GalleryToolsTests
+{
+    private const string AssetId = "asset-1";
+
+    [Fact]
+    public async Task ShowGallery_ReturnsStructuredMetadataAndMcpImageContent()
+    {
+        // Arrange
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        var asset = TestFixtures.CreateAsset(id: AssetId, originalFileName: "beach.jpg");
+        handler.When(HttpMethod.Get, $"*/assets/{AssetId}")
+            .Respond("application/json", TestFixtures.ToJson(asset));
+
+        var imageBytes = new byte[] { 0xFF, 0xD8, 0xFF, 0xE0, 0x01, 0x02, 0x03 };
+        handler.When(HttpMethod.Get, $"*/assets/{AssetId}/thumbnail")
+            .WithQueryString("size", "preview")
+            .Respond("image/jpeg", new MemoryStream(imageBytes));
+
+        // Act
+        var result = await GalleryTools.ShowGallery(client, [AssetId], "Foto al mare");
+
+        // Assert
+        result.IsError.Should().NotBeTrue();
+        result.StructuredContent.HasValue.Should().BeTrue();
+        var structured = result.StructuredContent!.Value;
+        structured.GetProperty("title").GetString().Should().Be("Foto al mare");
+        structured.GetProperty("images")[0].GetProperty("fileName").GetString().Should().Be("beach.jpg");
+        structured.GetRawText().Should().NotContain("data:image/");
+
+        result.Meta.Should().BeNull();
+        var image = result.Content.OfType<ImageContentBlock>().Should().ContainSingle().Subject;
+        image.MimeType.Should().Be("image/jpeg");
+        Convert.FromBase64String(System.Text.Encoding.ASCII.GetString(image.Data.ToArray()))
+            .Should().Equal(imageBytes);
+    }
+
+    [Fact]
+    public async Task ShowGallery_ReturnsAnErrorWhenNoAssetCanBeDisplayed()
+    {
+        // Arrange
+        var (client, handler) = MockHttpClientFactory.CreateMockClient();
+        handler.When(HttpMethod.Get, "*/assets/missing")
+            .Respond(HttpStatusCode.NotFound);
+
+        // Act
+        var result = await GalleryTools.ShowGallery(client, ["missing"]);
+
+        // Assert
+        result.IsError.Should().BeTrue();
+        result.Content.OfType<TextContentBlock>().Single().Text.Should().Contain("None of the requested Immich assets");
+    }
+
+    [Fact]
+    public void GalleryResource_UsesVersionedMcpAppTemplateAndStandardToolResultFields()
+    {
+        // Act
+        var resource = GalleryResource.GetGallery().Should().BeOfType<TextResourceContents>().Subject;
+
+        // Assert
+        resource.Uri.Should().Be("ui://immich/gallery-v1.html");
+        resource.MimeType.Should().Be("text/html;profile=mcp-app");
+        resource.Text.Should().Contain("ui/notifications/tool-result");
+        resource.Text.Should().Contain("openai:set_globals");
+        resource.Text.Should().Contain("toolResponseMetadata");
+        resource.Text.Should().Contain("mcp_tool_result");
+        resource.Text.Should().Contain("result?.structuredContent");
+        resource.Text.Should().Contain("result?.content");
+        resource.Text.Should().Contain("URL.createObjectURL");
+    }
+
+}

--- a/ImmichMCP/Program.cs
+++ b/ImmichMCP/Program.cs
@@ -28,7 +28,8 @@ if (useStdio)
     builder.Services
         .AddMcpServer(options => ConfigureMcpCapabilities(options, builder.Configuration))
         .WithStdioServerTransport()
-        .ConfigureTools(UseToolGateway(builder.Configuration));
+        .ConfigureTools(UseToolGateway(builder.Configuration))
+        .WithResourcesFromAssembly();
 
     await builder.Build().RunAsync();
 }
@@ -42,7 +43,8 @@ else
     builder.Services
         .AddMcpServer(options => ConfigureMcpCapabilities(options, builder.Configuration))
         .WithHttpTransport()
-        .ConfigureTools(UseToolGateway(builder.Configuration));
+        .ConfigureTools(UseToolGateway(builder.Configuration))
+        .WithResourcesFromAssembly();
 
     var app = builder.Build();
 
@@ -245,6 +247,10 @@ bool UseToolGateway(IConfiguration configuration)
 
 void ConfigureMcpCapabilities(McpServerOptions options, IConfiguration configuration)
 {
+    options.ServerInstructions = """
+        ImmichMCP searches and manages the user's private Immich library. For photo requests, first use the appropriate search, people, or asset tool to identify matching asset IDs. When the user asks to see, display, or browse photos, call immich_assets_show with the final asset IDs in the desired order. Do not answer a request to see photos with filenames or metadata alone.
+        """;
+
     if (!UseToolGateway(configuration))
     {
         return;

--- a/ImmichMCP/Resources/GalleryResource.cs
+++ b/ImmichMCP/Resources/GalleryResource.cs
@@ -1,0 +1,192 @@
+using System.ComponentModel;
+using System.Text.Json.Nodes;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace ImmichMCP.Resources;
+
+[McpServerResourceType]
+public static class GalleryResource
+{
+    [McpServerResource(
+        UriTemplate = Tools.GalleryTools.ResourceUri,
+        Name = "Immich photo gallery",
+        Title = "Immich photo gallery",
+        MimeType = "text/html;profile=mcp-app")]
+    [Description("Interactive inline gallery for selected Immich photos")]
+    public static ResourceContents GetGallery() => new TextResourceContents
+    {
+        Uri = Tools.GalleryTools.ResourceUri,
+        MimeType = "text/html;profile=mcp-app",
+        Text = GalleryHtml,
+        Meta = GalleryMeta()
+    };
+
+    private static JsonObject GalleryMeta() => new()
+    {
+        ["ui"] = new JsonObject
+        {
+            ["prefersBorder"] = true
+        }
+    };
+
+    private const string GalleryHtml = """
+        <!doctype html>
+        <html lang="en">
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width,initial-scale=1">
+          <style>
+            :root { color-scheme: light; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; --background: #fff; --foreground: #161616; --muted: #6b7280; --card: #f7f7f8; --border: #dedfe2; }
+            @media (prefers-color-scheme: dark) { :root { color-scheme: dark; --background: #212121; --foreground: #f3f4f6; --muted: #a3a3a3; --card: #2f2f2f; --border: #4b4b4b; } }
+            * { box-sizing: border-box; }
+            body { margin: 0; padding: 12px; color: var(--foreground); background: var(--background); }
+            header { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; margin: 0 0 10px; }
+            h1 { margin: 0; font-size: 18px; line-height: 1.3; }
+            #count { color: var(--muted); font-size: 13px; white-space: nowrap; }
+            #status { color: var(--muted); padding: 16px 2px; }
+            #gallery { display: grid; grid-template-columns: repeat(auto-fill, minmax(155px, 1fr)); gap: 10px; }
+            figure { margin: 0; min-width: 0; overflow: hidden; border: 1px solid var(--border); border-radius: 12px; background: var(--card); }
+            button { display: block; width: 100%; padding: 0; border: 0; background: transparent; cursor: zoom-in; }
+            img { display: block; width: 100%; aspect-ratio: 1 / 1; object-fit: cover; background: var(--card); }
+            figcaption { padding: 8px 9px 9px; min-width: 0; }
+            .name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12px; font-weight: 600; }
+            .meta { margin-top: 3px; color: var(--muted); font-size: 11px; line-height: 1.3; }
+            dialog { width: min(94vw, 1100px); max-width: 1100px; border: 0; border-radius: 14px; padding: 0; background: var(--background); color: var(--foreground); box-shadow: 0 20px 70px rgb(0 0 0 / .45); }
+            dialog::backdrop { background: rgb(0 0 0 / .72); }
+            dialog img { width: 100%; max-height: 78vh; aspect-ratio: auto; object-fit: contain; border-radius: 14px 14px 0 0; }
+            .dialog-meta { display: flex; justify-content: space-between; gap: 12px; padding: 10px 12px; font-size: 13px; }
+            .close { width: auto; padding: 3px 8px; color: inherit; cursor: pointer; font: inherit; }
+            @media (max-width: 420px) { body { padding: 8px; } #gallery { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 7px; } figcaption { padding: 7px; } }
+          </style>
+        </head>
+        <body>
+          <header><h1 id="title">Immich photos</h1><span id="count"></span></header>
+          <div id="status">Loading photos…</div>
+          <main id="gallery" aria-live="polite"></main>
+          <dialog id="viewer">
+            <img id="viewer-image" alt="">
+            <div class="dialog-meta"><span id="viewer-label"></span><button class="close" type="button">Close</button></div>
+          </dialog>
+          <script>
+            const title = document.getElementById("title");
+            const count = document.getElementById("count");
+            const status = document.getElementById("status");
+            const gallery = document.getElementById("gallery");
+            const viewer = document.getElementById("viewer");
+            const viewerImage = document.getElementById("viewer-image");
+            const viewerLabel = document.getElementById("viewer-label");
+            let objectUrls = [];
+
+            function formatDate(value) {
+              if (!value) return "";
+              const date = new Date(value);
+              return Number.isNaN(date.getTime()) ? "" : new Intl.DateTimeFormat(document.documentElement.lang || undefined, { dateStyle: "medium", timeStyle: "short" }).format(date);
+            }
+
+            function blobUrlFromImageBlock(block) {
+              try {
+                const binary = atob(block.data);
+                const bytes = new Uint8Array(binary.length);
+                for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index);
+                const url = URL.createObjectURL(new Blob([bytes], { type: block.mimeType }));
+                objectUrls.push(url);
+                return url;
+              } catch {
+                return null;
+              }
+            }
+
+            function render(result) {
+              const output = result?.structuredContent ?? null;
+              const imageBlocks = Array.isArray(result?.content)
+                ? result.content.filter(block => block?.type === "image" && typeof block.data === "string" && typeof block.mimeType === "string")
+                : [];
+              const images = Array.isArray(output?.images) ? output.images : [];
+              title.textContent = typeof output?.title === "string" ? output.title : "Immich photos";
+              count.textContent = images.length === 1 ? "1 photo" : `${images.length} photos`;
+              for (const url of objectUrls) URL.revokeObjectURL(url);
+              objectUrls = [];
+              gallery.replaceChildren();
+              status.hidden = images.length > 0;
+              status.textContent = images.length > 0 ? "" : "No photos to display.";
+
+              for (const [index, image] of images.entries()) {
+                const block = imageBlocks[index];
+                if (!image || !block || !block.mimeType.startsWith("image/")) continue;
+                const imageUrl = blobUrlFromImageBlock(block);
+                if (!imageUrl) continue;
+                const figure = document.createElement("figure");
+                const open = document.createElement("button");
+                open.type = "button";
+                const img = document.createElement("img");
+                img.src = imageUrl;
+                img.alt = typeof image.fileName === "string" ? image.fileName : "Immich photo";
+                img.loading = "eager";
+                open.append(img);
+                open.addEventListener("click", () => {
+                  viewerImage.src = imageUrl;
+                  viewerImage.alt = img.alt;
+                  viewerLabel.textContent = [image.fileName, formatDate(image.capturedAt), image.location].filter(Boolean).join(" · ");
+                  viewer.showModal();
+                });
+
+                const caption = document.createElement("figcaption");
+                const name = document.createElement("div");
+                name.className = "name";
+                name.textContent = typeof image.fileName === "string" ? image.fileName : "Photo";
+                const meta = document.createElement("div");
+                meta.className = "meta";
+                meta.textContent = [formatDate(image.capturedAt), image.location].filter(Boolean).join(" · ");
+                caption.append(name, meta);
+                figure.append(open, caption);
+                gallery.append(figure);
+              }
+            }
+
+            function resultFrom(params) {
+              return params?.toolResult ?? params?.result ?? params;
+            }
+
+            function normalizeResult(value) {
+              if (typeof value === "string") {
+                try { value = JSON.parse(value); } catch { return null; }
+              }
+              return value?.result ?? value ?? null;
+            }
+
+            function renderChatGptGlobals(globals) {
+              const metadata = globals?.toolResponseMetadata;
+              const fullResult = normalizeResult(metadata?.mcp_tool_result ?? metadata?.call_tool_result);
+              if (fullResult?.structuredContent || Array.isArray(fullResult?.content)) {
+                render(fullResult);
+                return;
+              }
+
+              if (globals?.toolOutput) {
+                render({ structuredContent: globals.toolOutput, content: [] });
+              }
+            }
+
+            window.addEventListener("message", (event) => {
+              if (event.source !== window.parent) return;
+              const message = event.data;
+              if (!message || message.jsonrpc !== "2.0") return;
+              if (message.method === "ui/initialize" || message.method === "ui/notifications/tool-result") {
+                render(resultFrom(message.params));
+              }
+            }, { passive: true });
+
+            window.addEventListener("openai:set_globals", (event) => {
+              renderChatGptGlobals(event.detail?.globals);
+            }, { passive: true });
+
+            viewer.querySelector(".close").addEventListener("click", () => viewer.close());
+            viewer.addEventListener("click", (event) => { if (event.target === viewer) viewer.close(); });
+
+            renderChatGptGlobals(window.openai);
+          </script>
+        </body>
+        </html>
+        """;
+}

--- a/ImmichMCP/Tools/GalleryTools.cs
+++ b/ImmichMCP/Tools/GalleryTools.cs
@@ -1,0 +1,156 @@
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ImmichMCP.Client;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace ImmichMCP.Tools;
+
+[McpServerToolType]
+public static class GalleryTools
+{
+    public const string ResourceUri = "ui://immich/gallery-v1.html";
+    private const int MaxAssets = 8;
+
+    [McpServerTool(
+        Name = "immich_assets_show",
+        Title = "Display Immich photos",
+        ReadOnly = true,
+        OpenWorld = false,
+        UseStructuredContent = true,
+        OutputSchemaType = typeof(GalleryOutput))]
+    [McpMeta("ui", JsonValue = """{"resourceUri":"ui://immich/gallery-v1.html"}""")]
+    [McpMeta("openai/outputTemplate", ResourceUri)]
+    [McpMeta("openai/toolInvocation/invoking", "Preparing the photo gallery…")]
+    [McpMeta("openai/toolInvocation/invoked", "Photo gallery ready")]
+    [Description("Display selected Immich photos as an inline MCP App gallery. First obtain the final asset IDs with an asset, people, or search tool, then pass them here in the desired order whenever the user asks to see, display, or browse photos.")]
+    public static async Task<CallToolResult> ShowGallery(
+        ImmichClient client,
+        [Description("Final Immich asset IDs to display, ordered as they should appear (maximum 8)")] string[] assetIds,
+        [Description("Short user-facing gallery title in the user's language")] string? title = null,
+        CancellationToken cancellationToken = default)
+    {
+        var ids = assetIds
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Take(MaxAssets)
+            .ToArray();
+
+        if (ids.Length == 0)
+        {
+            return Error("At least one Immich asset ID is required.");
+        }
+
+        var images = new List<LoadedGalleryImage>(ids.Length);
+        var missing = new List<string>();
+
+        foreach (var id in ids)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var asset = await client.GetAssetAsync(id, cancellationToken).ConfigureAwait(false);
+                if (asset is null)
+                {
+                    missing.Add(id);
+                    continue;
+                }
+
+                var (bytes, mimeType) = await client
+                    .DownloadAssetThumbnailAsync(id, cancellationToken)
+                    .ConfigureAwait(false);
+
+                images.Add(new LoadedGalleryImage(
+                    new GalleryImageSummary
+                    {
+                        Id = id,
+                        FileName = asset.OriginalFileName,
+                        CapturedAt = asset.ExifInfo?.DateTimeOriginal ?? asset.LocalDateTime,
+                        Location = FormatLocation(asset.ExifInfo?.City, asset.ExifInfo?.State, asset.ExifInfo?.Country)
+                    },
+                    bytes,
+                    mimeType));
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                missing.Add(id);
+            }
+        }
+
+        if (images.Count == 0)
+        {
+            return Error("None of the requested Immich assets could be loaded.");
+        }
+
+        var output = new GalleryOutput
+        {
+            Title = string.IsNullOrWhiteSpace(title) ? "Immich photos" : title.Trim(),
+            Images = images.Select(image => image.Summary).ToList(),
+            MissingAssetIds = missing
+        };
+
+        var content = new List<ContentBlock>
+        {
+            new TextContentBlock
+            {
+                Text = $"Displayed {images.Count} Immich photo{(images.Count == 1 ? string.Empty : "s")} in the gallery."
+            }
+        };
+        content.AddRange(images.Select(image => ImageContentBlock.FromBytes(image.Bytes, image.MimeType)));
+
+        return new CallToolResult
+        {
+            StructuredContent = JsonSerializer.SerializeToElement(output),
+            Content = content
+        };
+    }
+
+    private static CallToolResult Error(string message) => new()
+    {
+        IsError = true,
+        Content = [new TextContentBlock { Text = message }]
+    };
+
+    private static string? FormatLocation(string? city, string? state, string? country)
+    {
+        var parts = new[] { city, state, country }
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value!.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+
+        var location = string.Join(", ", parts);
+        return location.Length == 0 ? null : location;
+    }
+
+    private sealed record LoadedGalleryImage(GalleryImageSummary Summary, byte[] Bytes, string MimeType);
+}
+
+public sealed class GalleryOutput
+{
+    [JsonPropertyName("title")]
+    public string Title { get; init; } = "Immich photos";
+
+    [JsonPropertyName("images")]
+    public List<GalleryImageSummary> Images { get; init; } = [];
+
+    [JsonPropertyName("missingAssetIds")]
+    public List<string> MissingAssetIds { get; init; } = [];
+}
+
+public class GalleryImageSummary
+{
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = string.Empty;
+
+    [JsonPropertyName("fileName")]
+    public string FileName { get; init; } = string.Empty;
+
+    [JsonPropertyName("capturedAt")]
+    public DateTime CapturedAt { get; init; }
+
+    [JsonPropertyName("location")]
+    public string? Location { get; init; }
+}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Model Context Protocol (MCP) server for [Immich](https://immich.app/) - the se
 - **Asset Management**: Search, browse, upload, update, and delete photos/videos
 - **Direct Local Upload**: Authorize a short-lived, upload-only URL and stream a local folder straight to Immich — no API key exposed, nothing to install beyond `curl`, resumable by content dedup
 - **Smart Search**: ML-powered semantic search using CLIP (e.g., "sunset at the beach")
+- **ChatGPT Photo Gallery**: Show the final smart-search matches as private, inline thumbnail previews in ChatGPT
 - **Metadata Search**: Filter by date, location, camera, people, and more
 - **Albums**: Create, manage, and share photo albums
 - **People**: View and manage face recognition clusters
@@ -36,7 +37,7 @@ dotnet test ImmichMCP.Tests/ImmichMCP.Tests.csproj --filter "Category=Integratio
 ```
 
 Mutation coverage (create/update/delete paths) is disabled by default. Enable it explicitly
-to also run the full 49-tool smoke:
+to also run the full 50-tool smoke:
 
 ```bash
 export IMMICH_INTEGRATION_MUTATION_TESTS=true
@@ -46,7 +47,7 @@ dotnet test ImmichMCP.Tests/ImmichMCP.Tests.csproj --filter "Category=Integratio
 (If your Immich runs somewhere not directly reachable, point `IMMICH_BASE_URL` at it however
 you normally reach it — e.g. a port-forward or tunnel — before running the tests.)
 
-With mutation coverage enabled, `ToolCoverageIntegrationTests` exercises **all 49 tools**
+With mutation coverage enabled, `ToolCoverageIntegrationTests` exercises **all 50 tools**
 against the live server. It is strictly non-destructive to existing data: every mutation
 runs on throwaway fixtures the test creates (uploaded PNGs, an album, a tag, shared links,
 an activity) and teardown deletes only those; the two tools that would mutate real,
@@ -62,8 +63,8 @@ host containers — Docker, Docker Compose, or Kubernetes.
 - Expose the HTTP port (default `5000`). The MCP endpoint is served at `/mcp`. Two health
   endpoints are available: `/health` (liveness, use for restarts) and `/health/ready`
   (readiness, pings Immich and returns `503` if unreachable, use for traffic routing).
-- For remote/HTTP clients, set `IMMICH_TOOL_MODE=gateway` so clients enable tool categories on
-  demand instead of loading all tools up front.
+- For ChatGPT, set `IMMICH_TOOL_MODE=static` so ChatGPT receives the complete tool list when it
+  connects. `gateway` relies on a dynamic tool-list update that ChatGPT does not refresh reliably.
 
 ### Docker Compose
 
@@ -121,6 +122,12 @@ docker run -e IMMICH_BASE_URL="https://photos.example.com" \
 
 In `gateway` mode, `immich_tools_enable` emits the MCP `notifications/tools/list_changed` notification so clients can refresh the normal `tools/list` inventory after enabling a category or tool.
 
+For a ChatGPT connection, use `IMMICH_TOOL_MODE=static`. The `immich_assets_show` tool is a
+read-only render step: first run `immich_search_smart` (or a people/metadata search), then pass
+the final asset IDs to the gallery. Immich performs the visual search; only the selected thumbnail
+previews are returned as MCP image blocks and rendered by the ChatGPT component. The structured
+result contains only lightweight IDs and metadata, not base64 image text.
+
 ## Claude Desktop Configuration
 
 Add to your Claude Desktop config (`~/.config/claude/claude_desktop_config.json` on Linux/macOS or `%APPDATA%\Claude\claude_desktop_config.json` on Windows):
@@ -174,6 +181,7 @@ Or with Docker:
 | `immich_assets_exif` | Get EXIF data for an asset |
 | `immich_assets_download_original` | Get download URL for original (or inline content with `DOWNLOAD_MODE=base64`) |
 | `immich_assets_download_thumbnail` | Get thumbnail/preview URLs (or inline preview image with `DOWNLOAD_MODE=base64`) |
+| `immich_assets_show` | Display up to 8 final selected assets as an inline ChatGPT photo gallery |
 | `immich_assets_upload` | Upload asset (base64) |
 | `immich_assets_upload_from_path` | Upload from local file path |
 | `immich_assets_upload_authorize` | Mint a short-lived, upload-only URL so a client can upload local files **directly** to Immich (no API key exposed) |


### PR DESCRIPTION
## Summary

- add a read-only immich_assets_show tool for displaying up to eight selected assets
- serve a responsive MCP App resource for inline thumbnail galleries
- return image bytes as standard MCP image content blocks while keeping structured content lightweight
- register resources for both stdio and HTTP transports and guide clients to use the display step
- extend unit, gateway, and live-tool coverage for the new tool

## Why

Search tools can identify relevant Immich assets, but clients otherwise tend to stop at filenames and metadata. This gives MCP App-capable clients a dedicated final render step without exposing public image URLs or embedding base64 data in structured content.

## Implementation notes

- Immich still performs search and face/object matching; only final selected thumbnails are fetched.
- The result is capped at eight assets.
- The component supports standard MCP Apps tool-result notifications and the current ChatGPT globals compatibility path.
- The viewer creates local Blob URLs from MCP image blocks and revokes them before each rerender.

## Validation

- dotnet test ImmichMCP.sln -c Release: 168 passed, 10 skipped, 0 failed
- dotnet format ImmichMCP.sln --verify-no-changes: passed

The skipped tests are live Immich integration tests that require explicit server credentials.